### PR TITLE
Fixes issue with StacksPet

### DIFF
--- a/src/main/datatypes/MQ2SpellType.cpp
+++ b/src/main/datatypes/MQ2SpellType.cpp
@@ -639,17 +639,19 @@ bool MQ2SpellType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, M
 			if (!pBuffSpell)
 				continue;
 
-			if (WillStackWith(pSpell, pBuffSpell))
-				return true;
-
-			// if we have less duration than the duration argument, then this "will stack" so we need to keep checking
-			int duration = GetIntFromString(Index, 0);
-			if (duration != 0
-				&& (GetSpellDuration(pBuffSpell, pLocalPlayer) < -1 ||
-				ceil(pPetInfoWnd->PetBuffTimer[nBuff] / 6000) > duration))
+			// Buff found that will NOT stack with Spell
+			if (!WillStackWith(pSpell, pBuffSpell))
 			{
-				Dest.Set(false);
-				return true;
+				// Spell "will NOT stack" if
+				// Duration argument is 0 (ignores duration check) OR
+				// Blocking buff duration is greater than duration argument
+				int duration = GetIntFromString(Index, 0);
+				if (duration == 0 ||
+					(GetSpellDuration(pBuffSpell, pLocalPlayer) < -1 || ceil(pPetInfoWnd->PetBuffTimer[nBuff] / 6000) > duration))
+				{
+					Dest.Set(false);
+					return true;
+				}
 			}
 		}
 


### PR DESCRIPTION
Recent StacksPet change made it so that on the first stackable buff the function would exit with a value of TRUE.  Preventing a check of any other buffs the pet may have.

This change modifies the function somewhat back to how it was, while keeping the spirit of the previous change making duration check ignored with a 0 argument.  Also hopefully comments to clarify what is going on.