### PR TITLE
Fixes WillLandPet to match WillLand Behaviour

### DIFF
--- a/src/main/datatypes/MQ2SpellType.cpp
+++ b/src/main/datatypes/MQ2SpellType.cpp
@@ -668,8 +668,17 @@ bool MQ2SpellType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, M
 		for (int nBuff = 0; nBuff < MAX_TOTAL_BUFFS; nBuff++)
 		{
 			auto pBuffSpell = GetSpellByID(pPetInfoWnd->Buff[nBuff]);
+
+			// Spell does NOT stack (will NOT land)
 			if (pBuffSpell && !WillStackWith(pSpell, pBuffSpell))
 			{
+				// Exit with default value
+				return true;
+			}
+			// Invalid Spell, Empty Slot?
+			else if (!pBuffSpell)
+			{
+				// Exit with first empty slot value
 				Dest.Set(nBuff + 1);
 				return true;
 			}

--- a/src/main/datatypes/MQ2SpellType.cpp
+++ b/src/main/datatypes/MQ2SpellType.cpp
@@ -672,10 +672,10 @@ bool MQ2SpellType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, M
 			// Spell does NOT stack (will NOT land)
 			if (pBuffSpell && !WillStackWith(pSpell, pBuffSpell))
 			{
-				// Exit with default value
+				// Exit with default value (0 Will NOT Land)
 				return true;
 			}
-			// Invalid Spell, Empty Slot?
+			// Invalid Spell, Empty Slot
 			else if (!pBuffSpell)
 			{
 				// Exit with first empty slot value


### PR DESCRIPTION
WillLandPet was set up to return the slot number of the first blocking buff, if no buffs are preventing a spell land it would return 0.  WillLand logic is set up to return the slot number the spell would land in, otherwise 0 for wont land (blocking buff or slots full).

This change modifies WillLandPet to return 0 it a buff that will block the spell from landing is detected, or if the buff slots are full.  Otherwise returns the slot number of the first empty slot it finds.