### PR TITLE
Prevent delay strings with no units in lua (#566)

### DIFF
--- a/data/resources/CHANGELOG.md
+++ b/data/resources/CHANGELOG.md
@@ -1,4 +1,7 @@
-Maya 20, 2022:
+May 26, 2022:
+- lua: Throw error if string argument to mq.delay contains no time unit.
+
+May 20, 2022:
 - Fix /drop (#564)
 
 May 18, 2022:

--- a/src/plugins/lua/LuaCoroutine.cpp
+++ b/src/plugins/lua/LuaCoroutine.cpp
@@ -72,7 +72,7 @@ bool LuaCoroutine::CheckCondition(std::optional<sol::function>& func)
 	return false;
 }
 
-void LuaCoroutine::Delay(sol::object delayObj, sol::object conditionObj)
+void LuaCoroutine::Delay(sol::object delayObj, sol::object conditionObj, sol::state_view s)
 {
 	using namespace std::chrono_literals;
 
@@ -95,6 +95,11 @@ void LuaCoroutine::Delay(sol::object delayObj, sol::object conditionObj)
 			{
 				delay_int.emplace(std::chrono::duration_cast<std::chrono::milliseconds>(
 					std::chrono::seconds(GetIntFromString(*delay_str, 0))).count());
+			}
+			else
+			{
+				luaL_error(s, "Units are required when passing delay as a string.");
+				return;
 			}
 		}
 	}

--- a/src/plugins/lua/LuaCoroutine.h
+++ b/src/plugins/lua/LuaCoroutine.h
@@ -32,7 +32,7 @@ struct LuaCoroutine
 	std::optional<sol::function> m_delayCondition = std::nullopt;
 
 	bool CheckCondition(std::optional<sol::function>& func);
-	void Delay(sol::object delayObj, sol::object conditionObj);
+	void Delay(sol::object delayObj, sol::object conditionObj, sol::state_view s);
 	void SetDelay(uint64_t time, std::optional<sol::function> condition = std::nullopt);
 	void ClearDelay();
 

--- a/src/plugins/lua/LuaThread.cpp
+++ b/src/plugins/lua/LuaThread.cpp
@@ -177,7 +177,7 @@ void LuaThread::InjectMQNamespace()
 	{
 		if (auto co_ptr = thread_ptr->GetCurrentCoroutine())
 		{
-			co_ptr->Delay(delayObj, conditionObj);
+			co_ptr->Delay(delayObj, conditionObj, s);
 		}
 	}
 }


### PR DESCRIPTION
Update Lua `mq.delay` function to error if a string argument is provided with no time unit.

Example:
```
> /lua run delay
Running lua script 'delay' with PID 1
start
e:/git/macroquest/lua\delay.lua:4: Units are required when passing delay as a string.
stack traceback:
	[C]: in function 'delay'
	e:/git/macroquest/lua\delay.lua:4: in main chunk
Ending lua script 'delay' with PID 1 and status 2
```