### PR TITLE
Campfire / Aura Semi Spawn Type Fix

### DIFF
--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -6531,8 +6531,8 @@ eSpawnType GetSpawnType(SPAWNINFO* pSpawn)
 			//    return TRIGGER;
 
 		case 100: // Untargetable
-			return UNTARGETABLE
-				;
+			return UNTARGETABLE;
+
 		case 101: // Property Trap
 			return TRAP;
 

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -6467,30 +6467,30 @@ eSpawnType GetSpawnType(SPAWNINFO* pSpawn)
 
 		switch (GetBodyType(pSpawn))
 		{
-		case 0:
+		case 0: // Object
 			if (pSpawn->GetClass() == Class_Object)
 				return OBJECT;
 			return NPC;
 
-		case 1:
-			if (pSpawn->GetRace() == EQR_CAMPSITE)
-				return CAMPFIRE;
+		case 1: // Humanoid
 			if (pSpawn->GetRace() == EQR_BANNER
 				|| (pSpawn->GetRace() >= EQR_BANNER0 && pSpawn->GetRace() <= EQR_BANNER4) || pSpawn->GetRace() == EQR_TCGBANNER)
 				return BANNER;
 			return NPC;
 
-			//case 3:
+			//case 3: // Undead
 			//    return NPC;
 
-		case 5:
+		case 5: // Construct
 			if (strstr(pSpawn->Name, "Idol") || strstr(pSpawn->Name, "Poison") || strstr(pSpawn->Name, "Rune"))
 				return AURA;
 			if (pSpawn->GetClass() == Class_Object)
 				return OBJECT;
 			return NPC;
 
-		case 7:
+		case 7: // Magical
+			if (pSpawn->GetRace() == EQR_CAMPSITE)
+				return CAMPFIRE;
 			if (pSpawn->GetClass() == Class_Object)
 				return OBJECT;
 			return NPC;
@@ -6500,33 +6500,33 @@ eSpawnType GetSpawnType(SPAWNINFO* pSpawn)
 				return AURA;
 			return UNTARGETABLE;
 
-			//case 21:
+			//case 21: // Animal
 			//    return NPC;
-			//case 23:
+			//case 23: // Monster
 			//    return NPC;
 
-		case 33:
+		case 33: // Cursed
 			return CHEST;
 
-			//case 34:
+			//case 34: // Muramite
 			//    return NPC;
-			//case 65:
+			//case 65: // Trap
 			//    return TRAP;
-			//case 66:
+			//case 66: // Timer
 			//    return TIMER;
-			//case 67:
+			//case 67: // Trigger
 			//    return TRIGGER;
 
-		case 100:
+		case 100: // Untargetable
 			return UNTARGETABLE
 				;
-		case 101:
+		case 101: // Property Trap
 			return TRAP;
 
-		case 102:
+		case 102: // Property Companion
 			return TIMER;
 
-		case 103:
+		case 103: // Property Suicide
 			return TRIGGER;
 
 		default: break;

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -6483,10 +6483,10 @@ eSpawnType GetSpawnType(SPAWNINFO* pSpawn)
 
 		case 5: // Construct
 			// "Invisible Man" Race containing "Aura" in the Name
-			if ((pSpawn->GetRace() == 127) && strstr(pSpawn->Name, "Aura"))
+			if ((pSpawn->GetRace() == EQR_INVISIBLE_MAN) && strstr(pSpawn->Name, "Aura"))
 				return AURA;
 			// "Spike Trap" Race containing "Poison" in the Name
-			if ((pSpawn->GetRace() == 513) && (strstr(pSpawn->Name, "poison") || strstr(pSpawn->Name, "Poison")))
+			if ((pSpawn->GetRace() == EQR_SPIKE_TRAP) && (strstr(pSpawn->Name, "poison") || strstr(pSpawn->Name, "Poison")))
 				return AURA;
 			// Contains "Rune" in the Name
 			if (strstr(pSpawn->Name, "Rune"))
@@ -6501,7 +6501,7 @@ eSpawnType GetSpawnType(SPAWNINFO* pSpawn)
 			if (pSpawn->GetRace() == EQR_CAMPSITE)
 				return CAMPFIRE;
 			// "Totem" Race containing "Idol" in the Name
-			if ((pSpawn->GetRace() == 514) && strstr(pSpawn->Name, "Idol"))
+			if ((pSpawn->GetRace() == EQR_TOTEM) && strstr(pSpawn->Name, "Idol"))
 				return AURA;
 			// Object Class
 			if (pSpawn->GetClass() == Class_Object)

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -6482,20 +6482,33 @@ eSpawnType GetSpawnType(SPAWNINFO* pSpawn)
 			//    return NPC;
 
 		case 5: // Construct
-			if (strstr(pSpawn->Name, "Idol") || strstr(pSpawn->Name, "Poison") || strstr(pSpawn->Name, "Rune"))
+			// "Invisible Man" Race containing "Aura" in the Name
+			if ((pSpawn->GetRace() == 127) && strstr(pSpawn->Name, "Aura"))
 				return AURA;
+			// "Spike Trap" Race containing "Poison" in the Name
+			if ((pSpawn->GetRace() == 513) && (strstr(pSpawn->Name, "poison") || strstr(pSpawn->Name, "Poison")))
+				return AURA;
+			// Contains "Rune" in the Name
+			if (strstr(pSpawn->Name, "Rune"))
+				return AURA;
+			// Object Class
 			if (pSpawn->GetClass() == Class_Object)
 				return OBJECT;
 			return NPC;
 
 		case 7: // Magical
+			// "Campfire" Race
 			if (pSpawn->GetRace() == EQR_CAMPSITE)
 				return CAMPFIRE;
+			// "Totem" Race containing "Idol" in the Name
+			if ((pSpawn->GetRace() == 514) && strstr(pSpawn->Name, "Idol"))
+				return AURA;
+			// Object Class
 			if (pSpawn->GetClass() == Class_Object)
 				return OBJECT;
 			return NPC;
 
-		case 11:
+		case 11: // Untargetable
 			if (strstr(pSpawn->Name, "Aura") || strstr(pSpawn->Name, "Circle_of") || strstr(pSpawn->Name, "Guardian_Circle") || strstr(pSpawn->Name, "Earthen_Strength"))
 				return AURA;
 			return UNTARGETABLE;


### PR DESCRIPTION
Somewhat Corrects Issue #561

From the recent patch that changed Body Types around it seems Aura and other Aura like abilities got changed around as well.
I have limited access to a variety of Aura but from what I have access too this is what I have found.

Campfire now seem to be "magical" instead of "humanoid".
Normal Aura now seem to be "construct" instead of "untargetable"
Shaman Idol now seem to be "magical" instead of "construct"

These changes move those three to their correct locations, and add race checks for anything relevant to hopefully narrow results. I left the Aura and other 3 items under "utnargetable" untouched just in case. Just like Rune remains under "construct".

I was unable to test the following:
Banner - Moved from "humanoid" to "magical" like campfire was?
Rune - Still "construct" or now "magical" like Idol?
Circle_of / Guardian_Circle / Earthen_Strength - Still "untargetable" or "magical" / "construct" now?