### PR TITLE
Store radius values of mapfilters. Fixes #600

### DIFF
--- a/src/plugins/map/MQ2Map.cpp
+++ b/src/plugins/map/MQ2Map.cpp
@@ -263,15 +263,27 @@ PLUGIN_API void InitializePlugin()
 	{
 		MapFilterOption& option = MapFilterOptions[i];
 
-		// If it's the CampRadius or PullRadius, let's not get the last on/off state, lets assume it's off so we don't draw a circle at 0, 0.
-		if (_stricmp(option.szName, "CampRadius") && _stricmp(option.szName, "PullRadius"))
+		option.Enabled = GetPrivateProfileInt("Map Filters", option.szName, option.Default, INIFileName);
+		// If it's the CampRadius or PullRadius, set the radius value as well as the loc
+		if (!_stricmp(option.szName, "CampRadius"))
 		{
-			option.Enabled = GetPrivateProfileInt("Map Filters", option.szName, option.Default, INIFileName);
+			option.Radius = GetPrivateProfileFloat("Map Filters", option.szName, option.Default, INIFileName);
+			if (pLocalPlayer && option.Radius > 0.0f)
+			{
+				CampX = pLocalPlayer->X;
+				CampY = pLocalPlayer->Y;
+			}
 		}
-		else
+		if (!_stricmp(option.szName, "PullRadius"))
 		{
-			option.Enabled = 0;
+			option.Radius = GetPrivateProfileFloat("Map Filters", option.szName, option.Default, INIFileName);
+			if (pLocalPlayer && option.Radius > 0.0f)
+			{
+				PullX = pLocalPlayer->X;
+				PullY = pLocalPlayer->Y;
+			}
 		}
+		// How about spell radius or target radius?
 
 		// Lets see what color option was last saved as, if any. If none then use the default.
 		option.Color.SetARGB(GetPrivateProfileInt("Map Filters", fmt::format("{}-Color", option.szName), option.DefaultColor.ToARGB(), INIFileName));

--- a/src/plugins/map/MQ2Map.cpp
+++ b/src/plugins/map/MQ2Map.cpp
@@ -263,7 +263,7 @@ PLUGIN_API void InitializePlugin()
 	{
 		MapFilterOption& option = MapFilterOptions[i];
 
-		option.Enabled = GetPrivateProfileInt("Map Filters", option.szName, option.Default, INIFileName);
+		option.Enabled = GetPrivateProfileBool("Map Filters", option.szName, option.Default, INIFileName);
 		// If it's the CampRadius or PullRadius, set the radius value as well as the loc
 		if (!_stricmp(option.szName, "CampRadius"))
 		{
@@ -283,7 +283,6 @@ PLUGIN_API void InitializePlugin()
 				PullY = pLocalPlayer->Y;
 			}
 		}
-		// How about spell radius or target radius?
 
 		// Lets see what color option was last saved as, if any. If none then use the default.
 		option.Color.SetARGB(GetPrivateProfileInt("Map Filters", fmt::format("{}-Color", option.szName), option.DefaultColor.ToARGB(), INIFileName));

--- a/src/plugins/map/MQ2MapCommands.cpp
+++ b/src/plugins/map/MQ2MapCommands.cpp
@@ -154,7 +154,7 @@ void MapFilterSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* szValu
 	}
 }
 
-void MapFilterColorSetting(MapFilter nMapFilter, const char* szValue /* = nullptr */)
+void MapFilterColorSetting(MapFilter nMapFilter, const char* szValue)
 {
 	char szArg[MAX_STRING] = { 0 };
 	MapFilterOption option = MapFilterOptions[static_cast<size_t>(nMapFilter)];
@@ -187,7 +187,7 @@ void MapFilterColorSetting(MapFilter nMapFilter, const char* szValue /* = nullpt
 	}
 }
 
-void MapFilterRadiusSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* szValue /* = nullptr */)
+void MapFilterRadiusSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* szValue)
 {
 	if (!pChar) return;
 	MapFilterOption* option = &MapFilterOptions[static_cast<size_t>(nMapFilter)];
@@ -205,7 +205,6 @@ void MapFilterRadiusSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* 
 		PullX = pChar->X;
 		PullY = pChar->Y;
 	}
-	// How about spell radius or target radius?
 
 	WriteChatf("%s is now set to: %.2f", option->szName, option->Radius);
 	WritePrivateProfileFloat("Map Filters", option->szName, option->Radius, INIFileName);

--- a/src/plugins/map/MQ2MapCommands.cpp
+++ b/src/plugins/map/MQ2MapCommands.cpp
@@ -71,6 +71,10 @@ void MapFilterSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* szValu
 				sprintf_s(szBuffer, "%s: %s", pMapFilter->szName, FormatSearchSpawn(Buff, sizeof(Buff), &MapFilterCustom));
 			}
 		}
+		else if (pMapFilter->UsesRadius)
+		{
+			sprintf_s(szBuffer, "%s: %0.2f", pMapFilter->szName, pMapFilter->Radius);
+		}
 		else
 		{
 			sprintf_s(szBuffer, "%s: %d", pMapFilter->szName, pMapFilter->Enabled);
@@ -142,31 +146,69 @@ void MapFilterSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* szValu
 				WriteChatf("%s %s", pMapFilter->szName, FormatMarker(szValue, Buff, sizeof(Buff)));
 			}
 		}
-		else
-		{
-			pMapFilter->Radius = GetFloatFromString(szValue, 0.0f);
-			pMapFilter->Enabled = pMapFilter->Radius > 0.0f;
-
-			if (pMapFilter->Radius > 0.0f && !_stricmp(pMapFilter->szName, "CampRadius"))
-			{
-				CampX = pChar->X;
-				CampY = pChar->Y;
-			}
-
-			if (pMapFilter->Radius > 0.0f && !_stricmp(pMapFilter->szName , "PullRadius"))
-			{
-				PullX = pChar->X;
-				PullY = pChar->Y;
-			}
-
-			WriteChatf("%s is now set to: %.2f", pMapFilter->szName, pMapFilter->Radius);
-		}
 	}
 
 	if (szValue)
 	{
 		WritePrivateProfileBool("Map Filters", pMapFilter->szName, pMapFilter->Enabled, INIFileName);
 	}
+}
+
+void MapFilterColorSetting(MapFilter nMapFilter, const char* szValue /* = nullptr */)
+{
+	char szArg[MAX_STRING] = { 0 };
+	MapFilterOption option = MapFilterOptions[static_cast<size_t>(nMapFilter)];
+
+	if (!option.HasColor())
+	{
+		WriteChatf("Option '%s' does not have a color.", option.szName);
+	}
+	else
+	{
+		char szBuffer2[MAX_STRING] = { 0 };
+		GetArg(szArg, szValue, 2);
+
+		MQColor& color = option.Color;
+
+		if (szArg[0] == 0)
+		{
+			option.Color = option.DefaultColor;
+		}
+		else
+		{
+			uint8_t R = std::clamp(GetIntFromString(szArg, 255), 0, 255);
+			uint8_t G = std::clamp(GetIntFromString(GetArg(szArg, szValue, 3), 255), 0, 255);
+			uint8_t B = std::clamp(GetIntFromString(GetArg(szArg, szValue, 4), 255), 0, 255);
+			color = MQColor(R, G, B);
+		}
+
+		WriteChatf("Option '%s' color set to: %d %d %d", option.szName, color.Red, color.Green, color.Blue);
+		WritePrivateProfileInt("Map Filters", fmt::format("{}-Color", option.szName), option.Color.ToRGB(), INIFileName);
+	}
+}
+
+void MapFilterRadiusSetting(SPAWNINFO* pChar, MapFilter nMapFilter, const char* szValue /* = nullptr */)
+{
+	if (!pChar) return;
+	MapFilterOption* option = &MapFilterOptions[static_cast<size_t>(nMapFilter)];
+	option->Radius = GetFloatFromString(szValue, 0.0f);
+	option->Enabled = option->Radius > 0.0f;
+
+	if (option->Radius > 0.0f && !_stricmp(option->szName, "CampRadius"))
+	{
+		CampX = pChar->X;
+		CampY = pChar->Y;
+	}
+
+	if (option->Radius > 0.0f && !_stricmp(option->szName, "PullRadius"))
+	{
+		PullX = pChar->X;
+		PullY = pChar->Y;
+	}
+	// How about spell radius or target radius?
+
+	WriteChatf("%s is now set to: %.2f", option->szName, option->Radius);
+	WritePrivateProfileFloat("Map Filters", option->szName, option->Radius, INIFileName);
 }
 
 void MapFilters(SPAWNINFO* pChar, char* szLine)
@@ -212,32 +254,11 @@ void MapFilters(SPAWNINFO* pChar, char* szLine)
 			{
 				if (!_strnicmp(szRest, "color", 5))
 				{
-					if (!option.HasColor())
-					{
-						WriteChatf("Option '%s' does not have a color.", option.szName);
-					}
-					else
-					{
-						char szBuffer2[MAX_STRING] = { 0 };
-						GetArg(szArg, szRest, 2);
-
-						MQColor& color = option.Color;
-
-						if (szArg[0] == 0)
-						{
-							option.Color = option.DefaultColor;
-						}
-						else
-						{
-							uint8_t R = std::clamp(GetIntFromString(szArg, 255), 0, 255);
-							uint8_t G = std::clamp(GetIntFromString(GetArg(szArg, szRest, 3), 255), 0, 255);
-							uint8_t B = std::clamp(GetIntFromString(GetArg(szArg, szRest, 4), 255), 0, 255);
-							color = MQColor(R, G, B);
-						}
-
-						WriteChatf("Option '%s' color set to: %d %d %d", option.szName, color.Red, color.Green, color.Blue);
-						WritePrivateProfileInt("Map Filters", fmt::format("{}-Color", option.szName), option.Color.ToRGB(), INIFileName);
-					}
+					MapFilterColorSetting(static_cast<MapFilter>(i), szRest);
+				}
+				else if (option.UsesRadius)
+				{
+					MapFilterRadiusSetting(pChar, static_cast<MapFilter>(i), szRest);
 				}
 				else
 				{


### PR DESCRIPTION
- Updates `/mapf` command to output correct radius value instead of just 0/1 for radius filters.
- Updates `/mapf xyzradius #` to store the `#` in the INI instead of just `0/1`.
- Updates plugin init to read the radius value from the INI instead of skipping it. The existing comment here about why these radius weren't being set on load kinda makes sense though...

Not sure if anything extra is needed for target or spell radius, just updated for camp and pull.