### PR TITLE
Feature Added. IniExtKey.

### DIFF
--- a/src/main/MQ2DataAPI.cpp
+++ b/src/main/MQ2DataAPI.cpp
@@ -499,6 +499,7 @@ void InitializeMQ2Data()
 	AddMQ2Data("FrameLimiter", datatypes::MQ2FrameLimiterType::dataFrameLimiter);
 	AddMQ2Data("If", datatypes::dataIf);
 	AddMQ2Data("Ini", datatypes::dataIni);
+	AddMQ2Data("IniExtKey", datatypes::dataIniExtKey);
 	AddMQ2Data("Macro", datatypes::MQ2MacroType::dataMacro);
 	AddMQ2Data("MacroQuest", datatypes::MQ2MacroQuestType::dataMacroQuest);
 	AddMQ2Data("Math", datatypes::MQ2MathType::dataMath);

--- a/src/main/datatypes/MQ2DataTypes.h
+++ b/src/main/datatypes/MQ2DataTypes.h
@@ -1457,6 +1457,7 @@ public:
 bool dataIf(const char* szIndex, MQTypeVar& Ret);
 bool dataGameTime(const char* szIndex, MQTypeVar& Ret);
 bool dataIni(const char* szIndex, MQTypeVar& Ret);
+bool dataIniExtKey(const char* szIndex, MQTypeVar& Ret);
 bool dataDefined(const char* szIndex, MQTypeVar& Ret);
 bool dataSubDefined(const char* szIndex, MQTypeVar& Ret);
 bool dataLineOfSight(const char* szIndex, MQTypeVar& Ret);


### PR DESCRIPTION
Allows access to ini files with non unique keys.

Example usage
	return # of instances of the "Self Buff" key in the "Buffs" section
	${IniExtKey[<Path>\Character.ini,Buffs,Self Buff]}

	return the first index in the Buffs section of keys named "Self Buff"
	${IniExtKey[<Path>\Character.ini,Buffs,Self Buff,0]}

	return the second index in the Buffs section of keys named "Self Buff"
	${IniExtKey[<Path>\Character.ini,Buffs,Self Buff,1]}

	return the third index in the Buffs section of keys named "Self Buff", with noparse
	${IniExtKey[<Path>\Character.ini,Buffs,Self Buff,2,noparse]}