### PR TITLE
Time: add MilliSecond

### DIFF
--- a/src/main/MQ2Data.cpp
+++ b/src/main/MQ2Data.cpp
@@ -131,18 +131,17 @@ bool dataIf(const char* szIndex, MQTypeVar& Ret)
 
 bool dataGameTime(const char* szIndex, MQTypeVar& Ret)
 {
-	struct tm* pTime = (struct tm*)&DataTypeTemp[0];
-	ZeroMemory(pTime, sizeof(struct tm));
-	pTime->tm_sec = 0;
-	pTime->tm_min = pWorldData->Minute;
-	pTime->tm_hour = pWorldData->Hour - 1;
-	pTime->tm_mday = pWorldData->Day;
-	pTime->tm_mon = pWorldData->Month - 1;
-	pTime->tm_year = pWorldData->Year - 1900;
-	pTime->tm_wday = (pWorldData->Day - 1) % 7;
-	pTime->tm_isdst = 0;
+	SYSTEMTIME pTime;
+	ZeroMemory(&pTime, sizeof(SYSTEMTIME));
+	pTime.wSecond = 0;
+	pTime.wMinute = pWorldData->Minute;
+	pTime.wHour = pWorldData->Hour - 1;
+	pTime.wDay = pWorldData->Day;
+	pTime.wMonth = pWorldData->Month;
+	pTime.wYear = pWorldData->Year;
+	pTime.wDayOfWeek = (pWorldData->Day - 1) % 7;
 
-	Ret.Ptr = pTime;
+	Ret.Set(pTime);
 	Ret.Type = pTimeType;
 	return true;
 }

--- a/src/main/datatypes/MQ2BasicTypes.cpp
+++ b/src/main/datatypes/MQ2BasicTypes.cpp
@@ -1747,18 +1747,6 @@ bool MQ2TimeType::ToString(MQVarPtr VarPtr, char* Destination)
 	return true;
 }
 
-void MQ2TimeType::InitVariable(MQVarPtr& VarPtr)
-{
-	VarPtr.Ptr = new SYSTEMTIME();
-	ZeroMemory(VarPtr.Ptr, sizeof(SYSTEMTIME));
-}
-
-void MQ2TimeType::FreeVariable(MQVarPtr& VarPtr)
-{
-	SYSTEMTIME* Now = static_cast<SYSTEMTIME*>(VarPtr.Ptr);
-	delete Now;
-}
-
 bool MQ2TimeType::FromData(MQVarPtr& VarPtr, const MQTypeVar& Source)
 {
 	if (Source.Type != pTimeType)

--- a/src/main/datatypes/MQ2BasicTypes.cpp
+++ b/src/main/datatypes/MQ2BasicTypes.cpp
@@ -1606,6 +1606,7 @@ enum class TimeMembers
 	Hour,
 	Minute,
 	Second,
+	MilliSecond,
 	DayOfWeek,
 	Day,
 	Month,
@@ -1623,6 +1624,7 @@ MQ2TimeType::MQ2TimeType() : MQ2Type("time")
 	ScopedTypeMember(TimeMembers, Hour);
 	ScopedTypeMember(TimeMembers, Minute);
 	ScopedTypeMember(TimeMembers, Second);
+	ScopedTypeMember(TimeMembers, MilliSecond);
 	ScopedTypeMember(TimeMembers, DayOfWeek);
 	ScopedTypeMember(TimeMembers, Day);
 	ScopedTypeMember(TimeMembers, Month);
@@ -1669,6 +1671,13 @@ bool MQ2TimeType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQ
 
 	case TimeMembers::Second:
 		Dest.DWord = pTime->tm_sec;
+		Dest.Type = pIntType;
+		return true;
+
+	case TimeMembers::MilliSecond:
+		SYSTEMTIME nowMs;
+		GetSystemTime(&nowMs);
+		Dest.DWord = nowMs.wMilliseconds;
 		Dest.Type = pIntType;
 		return true;
 

--- a/src/main/datatypes/MQ2DataTypes.h
+++ b/src/main/datatypes/MQ2DataTypes.h
@@ -403,8 +403,6 @@ public:
 	bool GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest) override;
 	bool ToString(MQVarPtr VarPtr, char* Destination) override;
 
-	void InitVariable(MQVarPtr& VarPtr) override;
-	void FreeVariable(MQVarPtr& VarPtr) override;
 	bool FromData(MQVarPtr& VarPtr, const MQTypeVar& Source) override;
 
 	static bool dataTime(const char* szIndex, MQTypeVar& Ret);


### PR DESCRIPTION
Adds a property to the Time datatype to get the current millisecond.

Millisecond was available on the Timestamp datatype, but missing from Time.

This may have limited use, but I found it useful to measure latency on MQ2DanNet, where I need to query a TLO member directly.

