### PR TITLE
Typo fix in MQ2ImGuiTools

### DIFF
--- a/src/main/MQ2ImGuiTools.cpp
+++ b/src/main/MQ2ImGuiTools.cpp
@@ -197,7 +197,7 @@ void DoEditKeyComboPopup()
 
 void DoKeybindSettings()
 {
-	ImGui::Text("Clicking a binding will allow you change it.");
+	ImGui::Text("Clicking a binding will allow you to change it.");
 
 	std::string clickedName;
 	bool clickedAlt = false;


### PR DESCRIPTION
- Corrected a typo in "Key Bindings" settings panel