### PR TITLE
MQ2Commands - fix /removeaug

### DIFF
--- a/src/main/MQ2Commands.cpp
+++ b/src/main/MQ2Commands.cpp
@@ -5696,7 +5696,8 @@ static ItemPtr FindAugmentSolvent(const ItemPtr& pAugItem)
 	{
 		int realID = pDistillerInfo.GetIDFromRecordNum(i, false);
 
-		if (ItemPtr pItemSolvent = pLocalPC->GetItemByID(realID))
+		//if (ItemPtr pItemSolvent = pLocalPC->GetItemByID(realID))
+		if (ItemPtr pItemSolvent = FindItemByID(realID))
 		{
 			// found a distiller that will work...
 			return pItemSolvent;


### PR DESCRIPTION
- resolves #669 
- replaced pLocalPC->GetItemByID with FindItemByID
- this fixes /removeaug "aug name" "item"