### PR TITLE
Implements a Set / Remove Loot Filter Command

### DIFF
--- a/src/main/MQ2CommandAPI.cpp
+++ b/src/main/MQ2CommandAPI.cpp
@@ -962,6 +962,8 @@ void InitializeMQ2Commands()
 		{ "/removeaura",        RemoveAura,                 false, true  },
 #if HAS_ADVANCED_LOOT
 		{ "/advloot",           AdvLootCmd,                 true,  true  },
+		{ "/setlootfilter",     SetLootFilterCmd,           true,  true  },
+		{ "/removelootfilter",  RemoveLootFilterCmd,        true,  true  },
 #endif
 		{ "/pickzone",          PickZoneCmd,                true,  true  },
 		{ "/assist",            AssistCmd,                  true,  true  },

--- a/src/main/MQ2Commands.h
+++ b/src/main/MQ2Commands.h
@@ -119,6 +119,8 @@ MQLIB_API void PetCmd                              (PSPAWNINFO pChar, char* szLi
 MQLIB_API void MercSwitchCmd                       (PSPAWNINFO pChar, char* szLine);
 #if HAS_ADVANCED_LOOT
 MQLIB_API void AdvLootCmd                          (PSPAWNINFO pChar, char* szLine);
+MQLIB_API void SetLootFilterCmd                    (PSPAWNINFO pChar, char* szLine);
+MQLIB_API void RemoveLootFilterCmd                 (PSPAWNINFO pChar, char* szLine);
 #endif
 MQLIB_API void PickZoneCmd                         (PSPAWNINFO pChar, char* szLine);
 MQLIB_API void AssistCmd                           (PSPAWNINFO pChar, char* szLine);


### PR DESCRIPTION
- Implements /setlootfilter, used as /setlootfilter (option) \"itemID^itemIconID^itemName\"  
Option being AN|AG|NV|AR|ANAR|AGAR|NVAR, and the item portion being the line needed in the advloot inis.  
For example: /setlootfilter ANAR "13072^793^Rat Ears", setting Rat Ears to Always Need and Always Roll  
On use will add/set the advloot filter for the item given, with the option given.  Sets options to what was set, removes any previous options.  For example using AN will only set Always Need, Always Greed/Never/Always Roll will get removed.

- Implements /removelootfilter, used as /removelootfilter itemID  
For example: /removelootfilter 13072, which removes the advloot filter for Rat Ears
On use will remove the advloot filter for the item with the given item ID.  

Main reasoning for the commands is to simplify the process of setting advloot filters.  Avoids having to manually edit ini files, or situations in game where you may not have the item or its item link available to set the filters through the normal method. Also allows the user to broadcast one of these commands to modify advloot filters for multiple characters at the same time.