### PR TITLE
Put lib/exp files in MQ2LibDir on release build.

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -72,6 +72,10 @@
       <OptimizeReferences>false</OptimizeReferences>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
     </Link>
+    <!-- Release only compiler settings -->
+    <Link Condition="'$(Configuration)'=='Release'">
+      <ImportLibrary>$(MQ2LibDir)$(TargetName).lib</ImportLibrary>
+    </Link>
 
     <NASM>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
I find myself compiling this not only for myself but also for friends that play, and it's far more convenient to have these intermediate files placed elsewhere than it is to clean the directory after a build.  As an added benefit, with them going to the ./lib/ directory instead of the trash can, incremental builds are still available for faster compile times.