### PR TITLE
Fix PackFind to return correctly empty pack slot or inventory slot

### DIFF
--- a/include/moveitem.h
+++ b/include/moveitem.h
@@ -297,3 +297,44 @@ int FreeSlotForItem(ItemClient* pItem)
 	}
 	return 0;
 }
+
+CItemLocation* FreeItemLocationForItem(CItemLocation* pFreeSlot, ItemClient* pItemClient)
+{
+	unsigned char  ucCurSize = 10;
+	ItemDefinition* pUnequipInfo = pItemClient->GetItemDefinition();
+	if (!pUnequipInfo) {
+		return nullptr;
+	}
+
+	for (unsigned short usSlot = InvSlot_FirstBagSlot; usSlot <= GetHighestAvailableBagSlot(); usSlot++)
+	{
+		if (ItemClient* pInvSlot = GetPcProfile()->GetInventorySlot(usSlot))
+		{
+			ItemDefinition* pItemInfo = pInvSlot->GetItemDefinition();
+
+			if (pItemInfo
+				&& pItemInfo->Combine != 2
+				&& pInvSlot->IsContainer()
+				&& pUnequipInfo->Size <= pItemInfo->SizeCapacity)
+			{
+				for (unsigned short usPack = 0; usPack < pItemInfo->Slots; usPack++) {
+					if (!pInvSlot->GetHeldItem(usPack)) {
+						pFreeSlot->InvSlot = usSlot;
+						pFreeSlot->BagSlot = usPack;
+						pFreeSlot->pBagSlot = pInvSlot->GetHeldItem(usPack);
+						pFreeSlot->pInvSlot = pInvSlot;
+						return pFreeSlot;
+					}
+				}
+			}
+		}
+		else {
+			pFreeSlot->InvSlot = usSlot;
+			pFreeSlot->BagSlot = INVALID_PACK;
+			pFreeSlot->pBagSlot = nullptr;
+			pFreeSlot->pInvSlot = nullptr;
+			return pFreeSlot;
+		}
+	}
+	return nullptr;
+}

--- a/include/moveitem.h
+++ b/include/moveitem.h
@@ -302,26 +302,22 @@ CItemLocation* FreeItemLocationForItem(CItemLocation* pFreeSlot, ItemClient* pIt
 {
 	unsigned char  ucCurSize = 10;
 	ItemDefinition* pUnequipInfo = pItemClient->GetItemDefinition();
-	if (!pUnequipInfo) {
-		return nullptr;
-	}
 
 	for (unsigned short usSlot = InvSlot_FirstBagSlot; usSlot <= GetHighestAvailableBagSlot(); usSlot++)
 	{
 		if (ItemClient* pInvSlot = GetPcProfile()->GetInventorySlot(usSlot))
 		{
 			ItemDefinition* pItemInfo = pInvSlot->GetItemDefinition();
-
-			if (pItemInfo
-				&& pItemInfo->Combine != 2
+			if (pItemInfo->ContainerType != ContainerType_Quiver
 				&& pInvSlot->IsContainer()
 				&& pUnequipInfo->Size <= pItemInfo->SizeCapacity)
 			{
 				for (unsigned short usPack = 0; usPack < pItemInfo->Slots; usPack++) {
-					if (!pInvSlot->GetHeldItem(usPack)) {
+					auto pBagSlot = pInvSlot->GetHeldItem(usPack);
+					if (!pBagSlot) {
 						pFreeSlot->InvSlot = usSlot;
 						pFreeSlot->BagSlot = usPack;
-						pFreeSlot->pBagSlot = pInvSlot->GetHeldItem(usPack);
+						pFreeSlot->pBagSlot = pBagSlot;
 						pFreeSlot->pInvSlot = pInvSlot;
 						return pFreeSlot;
 					}


### PR DESCRIPTION
Fix PackFind to return correctly empty pack slot or inventory slot based on room for given item