### PR TITLE
Suggested fix #703 endmac from sub returning to wrong spot.

### DIFF
--- a/src/main/MQ2MacroCommands.cpp
+++ b/src/main/MQ2MacroCommands.cpp
@@ -1346,7 +1346,6 @@ void EndMacro(PSPAWNINFO pChar, char* szLine)
 	{
 		if (!_stricmp(":OnExit", i->second.Command.c_str()))
 		{
-			i++;
 			pBlock->CurrIndex = i->first;
 			// Force unpause to finish processing
 			pBlock->Paused = false;


### PR DESCRIPTION
Removed increment to next line after :OnExit since MQ2Pulse increments after Call command and a Sub calling /endmacro would result in losing 1 line of macro.

:OnExit must end with an /endmacro line since the presence of :OnExit catches the first call to /endmacro and halts it after unpausing and setting current index to :OnExit's location.
