### PR TITLE
Expose profile data for use in TLO AutoLogin, including hotkey.

### DIFF
--- a/src/plugins/autologin/MQ2AutoLogin.cpp
+++ b/src/plugins/autologin/MQ2AutoLogin.cpp
@@ -45,12 +45,13 @@ uint64_t ReenableTime = 0;
 int Level = -1;
 int Class = -1;
 
+std::optional<ProfileRecord> m_record_tlo = std::nullopt;
+
 class MQ2AutoLoginType* pAutoLoginType = nullptr;
 
 class MQ2AutoLoginType : public MQ2Type
 {
 public:
-	std::optional<ProfileRecord> m_record;
 	enum class AutoLoginMembers
 	{
 		HotKey,
@@ -79,40 +80,43 @@ public:
 		if (!pMember)
 			return false;
 
+		if (!m_record_tlo)
+			return false;
+
 		switch ((AutoLoginMembers)pMember->ID)
 		{
 		case AutoLoginMembers::HotKey:
-			strcpy_s(DataTypeTemp, m_record->hotkey.data());
+			strcpy_s(DataTypeTemp, m_record_tlo->hotkey.data());
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		case AutoLoginMembers::Server:
-			strcpy_s(DataTypeTemp, m_record->serverName.data());
+			strcpy_s(DataTypeTemp, m_record_tlo->serverName.data());
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		case AutoLoginMembers::Character:
-			strcpy_s(DataTypeTemp, m_record->characterName.data());
+			strcpy_s(DataTypeTemp, m_record_tlo->characterName.data());
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		case AutoLoginMembers::Profile:
-			strcpy_s(DataTypeTemp, m_record->profileName.data());
+			strcpy_s(DataTypeTemp, m_record_tlo->profileName.data());
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		case AutoLoginMembers::Account:
-			strcpy_s(DataTypeTemp, m_record->accountName.data());
+			strcpy_s(DataTypeTemp, m_record_tlo->accountName.data());
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		case AutoLoginMembers::Class:
-			strcpy_s(DataTypeTemp, m_record->characterClass.data());
+			strcpy_s(DataTypeTemp, m_record_tlo->characterClass.data());
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		case AutoLoginMembers::Level:
-			Dest.Int = m_record->characterLevel;
+			Dest.Int = m_record_tlo->characterLevel;
 			Dest.Type = mq::datatypes::pIntType;
 			return true;
 		}
@@ -712,7 +716,6 @@ PLUGIN_API void OnPulse()
 			{ "news",                 "NEWS_OKButton"}
 		};
 
-		memcpy_s(&pAutoLoginType->m_record, sizeof(std::optional<ProfileRecord>), (const void *)Login::getrecord(), sizeof(std::optional<ProfileRecord>));
 		// Click through any dialogs, don't need a whole state for this
 		for (const auto& [windowName, buttonName] : PromptWindows)
 		{
@@ -743,7 +746,7 @@ PLUGIN_API void OnPulse()
 			else
 				Login::dispatch(LoginStateSensor(LoginState::ServerSelect, pServerWnd));
 		}
-
+		m_record_tlo = Login::getrecord();
 		ReenableTime = MQGetTickCount64() + STEP_DELAY;
 	}
 }

--- a/src/plugins/autologin/MQ2AutoLogin.h
+++ b/src/plugins/autologin/MQ2AutoLogin.h
@@ -237,6 +237,10 @@ public:
 	static std::string_view server() { return m_record ? m_record->serverName.c_str() : ""; }
 	static std::string_view profile() { return m_record ? m_record->profileName.c_str() : ""; }
 	static std::string_view account() { return m_record ? m_record->accountName.c_str() : ""; }
+	static std::string_view hotkey() { return m_record ? m_record->hotkey.c_str() : ""; }
+	static std::string_view characterClass() { return m_record ? m_record->characterClass.c_str() : ""; }
+	static int characterLevel() { return m_record ? m_record->characterLevel : 0; }
+	static std::optional<ProfileRecord>* getrecord() { return &m_record; }
 	static bool has_entry() { return m_record.has_value(); }
 	static const CXWnd* current_window() { return m_currentWindow; }
 	static const bool paused() { return m_paused; }

--- a/src/plugins/autologin/MQ2AutoLogin.h
+++ b/src/plugins/autologin/MQ2AutoLogin.h
@@ -240,7 +240,7 @@ public:
 	static std::string_view hotkey() { return m_record ? m_record->hotkey.c_str() : ""; }
 	static std::string_view characterClass() { return m_record ? m_record->characterClass.c_str() : ""; }
 	static int characterLevel() { return m_record ? m_record->characterLevel : 0; }
-	static std::optional<ProfileRecord>* getrecord() { return &m_record; }
+	static std::optional<ProfileRecord> getrecord() { return m_record; }
 	static bool has_entry() { return m_record.has_value(); }
 	static const CXWnd* current_window() { return m_currentWindow; }
 	static const bool paused() { return m_paused; }


### PR DESCRIPTION
Originally I was only exposing the hotkey, and saving it in the TLO class to a char array, and the TLO had only member HotKey.  The intent was to use it for things like /setwintitle, to see server, char, zone, hotkey, etc. to make clear while getting used to boxing groups, which char was on which hotkey.  Decided to just expose the additional data (other than password) via the TLO anyway.  The only imgui addition to the display for autologin I added was hotkey.