### PR TITLE
adds getAllGroundItems to MQLua (issue 728)

### DIFF
--- a/src/plugins/lua/bindings/lua_MQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_MQBindings.cpp
@@ -588,6 +588,7 @@ void RegisterBindings_MQ(LuaThread* thread, sol::table& mq)
 	// Direct Data Bindings
 	mq.set_function("getAllSpawns", &lua_getAllSpawns);
 	mq.set_function("getFilteredSpawns", &lua_getFilteredSpawns);
+	mq.set_function("getAllGroundItems", &lua_getAllGroundItems);
 	mq.set_function("getFilteredGroundItems", &lua_getFilteredGroundItems);
 }
 

--- a/src/plugins/lua/bindings/lua_MQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_MQBindings.cpp
@@ -256,6 +256,26 @@ static sol::table lua_getFilteredSpawns(sol::this_state L, std::optional<sol::fu
 	return table;
 }
 
+static sol::table lua_getAllGroundItems(sol::this_state L)
+{
+    auto table = sol::state_view(L).create_table();
+
+    if (pItemList)
+    {
+        auto pGroundItem = pItemList->Top;
+        while (pGroundItem != nullptr)
+        {
+            auto groundTypeVar = datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(pGroundItem));
+            auto lua_ground = lua_MQTypeVar(groundTypeVar);
+            table.add(std::move(lua_ground));
+
+            pGroundItem = pGroundItem->pNext;
+        }
+    }
+
+    return table;
+}
+
 static sol::table lua_getFilteredGroundItems(sol::this_state L, std::optional<sol::function> predicate)
 {
 	auto table = sol::state_view(L).create_table();


### PR DESCRIPTION
Adds the missing parity method to the Lua bindings as outlined in
https://github.com/macroquest/macroquest/issues/728