### PR TITLE
Add jit version to modules path

### DIFF
--- a/src/plugins/lua/LuaCommon.h
+++ b/src/plugins/lua/LuaCommon.h
@@ -68,6 +68,7 @@ private:
 	std::string m_packagePath;
 	std::string m_packageCPath;
 	std::string m_version;
+	std::string m_jitversion;
 };
 
 class LuaThread;

--- a/src/plugins/lua/lua/mq/PackageMan.lua
+++ b/src/plugins/lua/lua/mq/PackageMan.lua
@@ -1,5 +1,5 @@
-local PackageMan = { _version = '1.0', author = 'Knightly' }
--- This script uses ImguiHelper which currently relies on mq, so we can bring this in for ease of 
+local PackageMan = { _version = '1.1' }
+-- This script uses ImguiHelper which currently relies on mq, so we can bring this in for ease of
 -- other functions (like paths)
 local mq = require('mq')
 
@@ -12,14 +12,17 @@ local ImguiHelper = require('mq/ImguiHelper')
 local Utils = require('mq/Utils')
 
 -- Internal settings
-local mqRepoUrl = 'https://luarocks.macroquest.org/'
+local jitVersion = Utils.String.Split(jit.version, ' ')[2]
+local mqRepoUrl = 'https://luarocks.macroquest.org/' .. jitVersion .. '/'
 local mqRepoName = 'MacroQuest'
---- luarocks --lua-version 5.1 --only-server "https://luarocks.macroquest.org/" install --deps-mode none --tree modules\luarocks lsqlite3complete
+PackageMan.repoUrl = mqRepoUrl
+
+printf("PackageMan: Using LuaRocks repository '%s'", PackageMan.repoUrl)
+
+--- luarocks --lua-version 5.1 --only-server "https://luarocks.macroquest.org/2.1.0-beta3/" install --deps-mode none --tree modules\2.1.0-beta3\luarocks lsqlite3
 local cliVersionArg = Utils.String.Split(_VERSION, ' ')[2]
 local cliLuarocksPath = mq.TLO.MacroQuest.Path() .. '\\luarocks.exe'
-local cliInstallPath = mq.TLO.Lua.Dir('modules')() .. '\\luarocks'
-
--- Local functions
+local cliInstallPath = string.format("%s\\%s\\luarocks", mq.TLO.Lua.Dir('modules')(), jitVersion)
 
 -- Exposed functions
 
@@ -76,7 +79,7 @@ PackageMan.Install = function(package_name)
     return 0
 end
 
----@param package_name string The package name
+---@param package_name string The package name from luarocks
 ---@param require_name? string The package internal export name
 ---@return nil | any
 PackageMan.InstallAndLoad = function(package_name, require_name)
@@ -89,37 +92,9 @@ PackageMan.InstallAndLoad = function(package_name, require_name)
     return nil
 end
 
--- BEGIN WORKAROUND CODE ---
-local function search_paths(require_name, paths)
-    local file_name, _ = string.match(require_name, "([^%.]+)%.(.*)")
-    file_name = file_name or require_name
-    for path in string.gmatch(paths, "([^;]+)") do
-        local file = string.gsub(path, "?", file_name)
-        if Utils.File.Exists(file) then
-            return file
-        end
-    end
-    return nil
-end
-
-local function require_if_exists(require_name)
-    local file = search_paths(require_name, package.cpath)
-    if file then
-        return require(require_name)
-    end
-
-    file = search_paths(require_name, package.path)
-    if file ~= nil then
-        return require(require_name)
-    end
-
-    return nil
-end
--- END WORKAROUND CODE ---
-
----@param package_name string The package name
+---@param package_name string The package name from luarocks
 ---@param require_name? string The package internal export name
----@param fail_message? string Oevrride fail message if package fails to load
+---@param fail_message? string Override fail message if package fails to load
 ---@return any
 PackageMan.Require = function(package_name, require_name, fail_message)
     require_name = require_name or package_name
@@ -132,13 +107,11 @@ PackageMan.Require = function(package_name, require_name, fail_message)
     end
 
     if package_name then
-        -- This code is working around an issue using the pcall directly, see above workaround code
-        local my_package = require_if_exists(require_name)
+        local my_package = Utils.Library.Include(require_name)
         if not my_package then
-            if PackageMan.Install(package_name) == 0 then
-                return Utils.Library.Include(require_name)
-            end
-        else
+            my_package = PackageMan.InstallAndLoad(package_name, require_name)
+        end
+        if my_package then
             return my_package
         end
     end


### PR DESCRIPTION
- Prevents crashing when changing luajit versions
- Package Path now searches jitVersion folder first before falling back
- Package CPath now searches jitVersion folder (no fallback)
- Revert previous workaround for PackageMan now that issue has been fixed
- Add jitVersion path to PackageMan modules and URL for luarocks