### PR TITLE
Fix #780 , handle ERROR_MORE_DATA

### DIFF
--- a/src/common/NamedPipes.cpp
+++ b/src/common/NamedPipes.cpp
@@ -267,9 +267,12 @@ void PipeConnection::InternalBeginRead()
 
 	if (!readStarted)
 	{
-		SPDLOG_ERROR("{} connectionId={}",
-			fmt::windows_error(GetLastError(), "Failed at ::ReadFileEx").what(), m_connectionId);
-		m_parent->CloseConnection(this);
+		auto error = GetLastError();
+		if(error != ERROR_MORE_DATA) {
+			SPDLOG_ERROR("{} connectionId={}",
+				fmt::windows_error(error, "Failed at ::ReadFileEx").what(), m_connectionId);
+			m_parent->CloseConnection(this);
+		}
 	}
 }
 
@@ -331,11 +334,12 @@ void PipeConnection::HandleReadComplete(uint32_t errorCode, uint32_t bytesRead)
 
 	case ERROR_INSUFFICIENT_BUFFER:
 	case ERROR_SUCCESS:
+	case ERROR_MORE_DATA:
 		// Store the data in our buffers, and try to read more. If we've got all the
 		// data we need we can process it right after the next call to ReadFileEx.
 		m_readBuffers.emplace_back(std::move(m_readBuffer), bytesRead);
 
-		if (!moreData)
+		if (!moreData && errorCode != ERROR_MORE_DATA)
 		{
 			ProcessBuffers();
 		}


### PR DESCRIPTION
From #780:

> This is based on the documentation for _ReadFile_ rather than _ReadFileEx_:
> https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
> >If a named pipe is being read in message mode and the next message is longer than the nNumberOfBytesToRead parameter specifies, ReadFile returns FALSE and GetLastError returns ERROR_MORE_DATA. The remainder of the message can be read by a subsequent call to the ReadFile or PeekNamedPipe function.
> 
> ReadFileEx's documentation is silent on this.

This fixes the issue on Wine, but needs someone to test it on Windows.