### PR TITLE
Added new WindowType, InvSlotWindow

### DIFF
--- a/src/main/datatypes/MQ2DataTypes.h
+++ b/src/main/datatypes/MQ2DataTypes.h
@@ -765,7 +765,6 @@ public:
 	bool ToString(MQVarPtr VarPtr, char* Destination) override;
 
 	bool FromData(MQVarPtr& VarPtr, const MQTypeVar& Source) override;
-	bool FromString(MQVarPtr& VarPtr, const char* Source) override;
 };
 
 //============================================================================

--- a/src/main/datatypes/MQ2DataTypes.h
+++ b/src/main/datatypes/MQ2DataTypes.h
@@ -754,6 +754,23 @@ public:
 };
 
 //============================================================================
+// MQ2InvSlotWindowType
+
+class MQ2InvSlotWindowType : public MQ2Type
+{
+public:
+	MQ2InvSlotWindowType();
+
+	bool GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest) override;
+	bool ToString(MQVarPtr VarPtr, char* Destination) override;
+
+	bool FromData(MQVarPtr& VarPtr, const MQTypeVar& Source) override;
+	bool FromString(MQVarPtr& VarPtr, const char* Source) override;
+
+	static bool dataWindow(const char* szIndex, MQTypeVar& Ret);
+};
+
+//============================================================================
 // MQ2MenuType
 
 class MQ2MenuType : public MQ2Type

--- a/src/main/datatypes/MQ2DataTypes.h
+++ b/src/main/datatypes/MQ2DataTypes.h
@@ -766,8 +766,6 @@ public:
 
 	bool FromData(MQVarPtr& VarPtr, const MQTypeVar& Source) override;
 	bool FromString(MQVarPtr& VarPtr, const char* Source) override;
-
-	static bool dataWindow(const char* szIndex, MQTypeVar& Ret);
 };
 
 //============================================================================

--- a/src/main/datatypes/MQ2WindowType.cpp
+++ b/src/main/datatypes/MQ2WindowType.cpp
@@ -917,9 +917,6 @@ bool MQ2InvSlotWindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* 
 	if (pWnd->GetType() != UI_InvSlot)
 		return false;
 
-	if (!Index || !Index[0])
-		return false;
-
 	CInvSlotWnd* pInvWnd = static_cast<CInvSlotWnd*>(pWnd);
 
 	MQTypeMember* pMember = MQ2InvSlotWindowType::FindMember(Member);
@@ -1017,12 +1014,14 @@ bool MQ2InvSlotWindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* 
 
 bool MQ2InvSlotWindowType::ToString(MQVarPtr VarPtr, char* Destination)
 {
-	CXWnd* pWnd = static_cast<CXWnd*>(VarPtr.Ptr);
+	CInvSlotWnd* pWnd = static_cast<CInvSlotWnd*>(VarPtr.Ptr);
 
 	if (pWnd)
 	{
-		if (pWnd->IsVisible())
-			strcpy_s(Destination, MAX_STRING, "TRUE");
+		ItemPtr pItem = pWnd->LinkedItem ? pWnd->LinkedItem : pLocalPC->GetItemByGlobalIndex(pWnd->ItemLocation);
+
+		if (pItem && pWnd->IsVisible())
+			strcpy_s(Destination, MAX_STRING, pItem->GetName());
 		else
 			strcpy_s(Destination, MAX_STRING, "FALSE");
 	}
@@ -1042,20 +1041,6 @@ bool MQ2InvSlotWindowType::FromString(MQVarPtr& VarPtr, const char* Source)
 {
 	if (VarPtr.Ptr = FindMQ2WindowPath(Source))
 		return true;
-
-	return false;
-}
-
-bool MQ2InvSlotWindowType::dataWindow(const char* szIndex, MQTypeVar& Ret)
-{
-	if (szIndex[0])
-	{
-		if (Ret.Ptr = FindMQ2Window(szIndex))
-		{
-			Ret.Type = pInvSlotWindowType;
-			return true;
-		}
-	}
 
 	return false;
 }

--- a/src/main/datatypes/MQ2WindowType.cpp
+++ b/src/main/datatypes/MQ2WindowType.cpp
@@ -1015,17 +1015,21 @@ bool MQ2InvSlotWindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* 
 bool MQ2InvSlotWindowType::ToString(MQVarPtr VarPtr, char* Destination)
 {
 	CInvSlotWnd* pWnd = static_cast<CInvSlotWnd*>(VarPtr.Ptr);
+	bool bFound = false;
 
 	if (pWnd)
 	{
 		ItemPtr pItem = pWnd->LinkedItem ? pWnd->LinkedItem : pLocalPC->GetItemByGlobalIndex(pWnd->ItemLocation);
 
 		if (pItem && pWnd->IsVisible())
+		{
 			strcpy_s(Destination, MAX_STRING, pItem->GetName());
+			bFound = true;
+		}
 		else
-			strcpy_s(Destination, MAX_STRING, "FALSE");
+			strcpy_s(Destination, MAX_STRING, "NULL");
 	}
-	return true;
+	return bFound;
 }
 
 bool MQ2InvSlotWindowType::FromData(MQVarPtr& VarPtr, const MQTypeVar& Source)
@@ -1035,14 +1039,6 @@ bool MQ2InvSlotWindowType::FromData(MQVarPtr& VarPtr, const MQTypeVar& Source)
 
 	VarPtr.Ptr = Source.Ptr;
 	return true;
-}
-
-bool MQ2InvSlotWindowType::FromString(MQVarPtr& VarPtr, const char* Source)
-{
-	if (VarPtr.Ptr = FindMQ2WindowPath(Source))
-		return true;
-
-	return false;
 }
 
 } // namespace mq::datatypes

--- a/src/main/datatypes/MQ2WindowType.cpp
+++ b/src/main/datatypes/MQ2WindowType.cpp
@@ -34,6 +34,7 @@ enum class WindowMembers
 	HScrollMax,
 	HScrollPct,
 	HScrollPos,
+	InvSlot,
 	Items,
 	List,
 	Minimized,
@@ -100,6 +101,7 @@ MQ2WindowType::MQ2WindowType() : MQ2Type("window")
 	ScopedTypeMember(WindowMembers, HScrollMax);
 	ScopedTypeMember(WindowMembers, HScrollPct);
 	ScopedTypeMember(WindowMembers, HScrollPos);
+	ScopedTypeMember(WindowMembers, InvSlot);
 	ScopedTypeMember(WindowMembers, Items);
 	ScopedTypeMember(WindowMembers, List);
 	ScopedTypeMember(WindowMembers, Minimized);
@@ -144,6 +146,43 @@ MQ2WindowType::MQ2WindowType() : MQ2Type("window")
 	ScopedTypeMethod(WindowMethods, SetCurrentTab);
 	ScopedTypeMethod(WindowMethods, SetFadeAlpha);
 	ScopedTypeMethod(WindowMethods, SetText);
+}
+
+/* SubWindow Type: MQ2InvSlotWindowType */
+enum class InvSlotWindowMembers
+{
+	Background,
+	ItemLocation,
+	ItemIndexSlot,
+	Item,
+	ItemOffsetX,
+	ItemOffsetY,
+	ItemTexture,
+	Quantity,
+	Selected,
+	FindSelected,
+	HotButton,
+	InventorySlotLinked,
+	Text,
+	Mode,
+};
+
+MQ2InvSlotWindowType::MQ2InvSlotWindowType() : MQ2Type("invslotwindow")
+{
+	ScopedTypeMember(InvSlotWindowMembers, Background);
+	ScopedTypeMember(InvSlotWindowMembers, ItemLocation);
+	ScopedTypeMember(InvSlotWindowMembers, ItemIndexSlot);
+	ScopedTypeMember(InvSlotWindowMembers, Item);
+	ScopedTypeMember(InvSlotWindowMembers, ItemOffsetX);
+	ScopedTypeMember(InvSlotWindowMembers, ItemOffsetY);
+	ScopedTypeMember(InvSlotWindowMembers, Quantity);
+	ScopedTypeMember(InvSlotWindowMembers, Selected);
+	ScopedTypeMember(InvSlotWindowMembers, FindSelected);
+	ScopedTypeMember(InvSlotWindowMembers, HotButton);
+	ScopedTypeMember(InvSlotWindowMembers, InventorySlotLinked);
+	ScopedTypeMember(InvSlotWindowMembers, Text);
+	ScopedTypeMember(InvSlotWindowMembers, Mode);
+
 }
 
 bool MQ2WindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest)
@@ -630,6 +669,15 @@ bool MQ2WindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 		return false;
 	}
 
+	case WindowMembers::InvSlot:
+		if (pWnd->GetType() == UI_InvSlot)
+		{
+			Dest.Type = pInvSlotWindowType;
+			Dest.Ptr = VarPtr.Ptr;
+			return true;
+		}
+		return false;
+
 	case WindowMembers::Name:
 		Dest.Type = pStringType;
 		if (CXMLData* pXMLData = pWnd->GetXMLData())
@@ -760,7 +808,7 @@ bool MQ2WindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 		if (pWnd->GetType() == UI_TabBox && Index[0])
 		{
 			CTabWnd* pTabWnd = static_cast<CTabWnd*>(pWnd);
-			
+
 			if (IsNumber(Index))
 			{
 				int tabIndex = GetIntFromString(Index, 0) - 1;
@@ -853,6 +901,158 @@ bool MQ2WindowType::dataWindow(const char* szIndex, MQTypeVar& Ret)
 		if (Ret.Ptr = FindMQ2Window(szIndex))
 		{
 			Ret.Type = pWindowType;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool MQ2InvSlotWindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest)
+{
+	CXWnd* pWnd = static_cast<CXWnd*>(VarPtr.Ptr);
+	if (!VarPtr.Ptr)
+		return false;
+
+	if (pWnd->GetType() != UI_InvSlot)
+		return false;
+
+	if (!Index || !Index[0])
+		return false;
+
+	CInvSlotWnd* pInvWnd = static_cast<CInvSlotWnd*>(pWnd);
+
+	MQTypeMember* pMember = MQ2InvSlotWindowType::FindMember(Member);
+	if (!pMember)
+		return false;
+
+	switch (static_cast<InvSlotWindowMembers>(pMember->ID))
+	{
+
+	case InvSlotWindowMembers::Background:
+		Dest.Type = pStringType;
+		strcpy_s(DataTypeTemp, pInvWnd->pBackground->GetName().c_str());
+		Dest.Ptr = &DataTypeTemp[0];
+		return true;
+
+
+	case InvSlotWindowMembers::ItemLocation:
+		Dest.Type = pIntType;
+		Dest.DWord = pInvWnd->ItemLocation.GetLocation();
+		return true;
+
+	case InvSlotWindowMembers::ItemIndexSlot:
+		if (IsNumber(Index))
+		{
+			int nIndex = GetIntFromString(Index, 0);
+			Dest.Type = pIntType;
+			Dest.DWord = pInvWnd->ItemLocation.GetIndex().GetSlot(nIndex);
+			return true;
+		}
+		return false;
+
+
+	case InvSlotWindowMembers::Item:
+		Dest.Type = pItemType;
+		Dest = pItemType->MakeTypeVar(pInvWnd->LinkedItem ? pInvWnd->LinkedItem : pLocalPC->GetItemByGlobalIndex(pInvWnd->ItemLocation));
+		return true;
+
+	case InvSlotWindowMembers::ItemOffsetX:
+		Dest.Type = pIntType;
+		Dest.DWord = pInvWnd->ItemOffsetX;
+		return true;
+
+	case InvSlotWindowMembers::ItemOffsetY:
+		Dest.Type = pIntType;
+		Dest.DWord = pInvWnd->ItemOffsetY;
+		return true;
+
+	case InvSlotWindowMembers::ItemTexture:
+		Dest.Type = pStringType;
+		strcpy_s(DataTypeTemp, pInvWnd->ptItem->GetName().c_str());
+		Dest.Ptr = &DataTypeTemp[0];
+		return true;
+
+	case InvSlotWindowMembers::Quantity:
+		Dest.Type = pIntType;
+		Dest.DWord = pInvWnd->Quantity;
+		return true;
+
+	case InvSlotWindowMembers::Selected:
+		Dest.Type = pBoolType;
+		Dest.DWord = pInvWnd->bSelected;
+		return true;
+
+
+	case InvSlotWindowMembers::FindSelected:
+		Dest.Type = pBoolType;
+		Dest.DWord = pInvWnd->bFindSelected;
+		return true;
+
+	case InvSlotWindowMembers::HotButton:
+		Dest.Type = pBoolType;
+		Dest.DWord = pInvWnd->bHotButton;
+		return true;
+
+	case InvSlotWindowMembers::InventorySlotLinked:
+		Dest.Type = pBoolType;
+		Dest.DWord = pInvWnd->bInventorySlotLinked;
+		return true;
+
+	case InvSlotWindowMembers::Text:
+		Dest.Type = pStringType;
+		strcpy_s(DataTypeTemp, pInvWnd->pTextObject->GetText().c_str());
+		Dest.Ptr = &DataTypeTemp[0];
+		return true;
+
+
+	case InvSlotWindowMembers::Mode:
+		Dest.Type = pIntType;
+		Dest.DWord = pInvWnd->Mode;
+		return true;
+
+	}
+	return false;
+}
+
+bool MQ2InvSlotWindowType::ToString(MQVarPtr VarPtr, char* Destination)
+{
+	CXWnd* pWnd = static_cast<CXWnd*>(VarPtr.Ptr);
+
+	if (pWnd)
+	{
+		if (pWnd->IsVisible())
+			strcpy_s(Destination, MAX_STRING, "TRUE");
+		else
+			strcpy_s(Destination, MAX_STRING, "FALSE");
+	}
+	return true;
+}
+
+bool MQ2InvSlotWindowType::FromData(MQVarPtr& VarPtr, const MQTypeVar& Source)
+{
+	if (Source.Type != pInvSlotWindowType)
+		return false;
+
+	VarPtr.Ptr = Source.Ptr;
+	return true;
+}
+
+bool MQ2InvSlotWindowType::FromString(MQVarPtr& VarPtr, const char* Source)
+{
+	if (VarPtr.Ptr = FindMQ2WindowPath(Source))
+		return true;
+
+	return false;
+}
+
+bool MQ2InvSlotWindowType::dataWindow(const char* szIndex, MQTypeVar& Ret)
+{
+	if (szIndex[0])
+	{
+		if (Ret.Ptr = FindMQ2Window(szIndex))
+		{
+			Ret.Type = pInvSlotWindowType;
 			return true;
 		}
 	}


### PR DESCRIPTION
Added new WindowType, InvSlotWindow with the following properties:
- Background
- ItemLocation
- ItemIndexSlot1
- ItemIndexSlot2
- ItemIndexSlot3
- Item
- ItemOffsetX
- ItemOffsetY
- ItemTexture
- Quantity
- Selected
- FindSelected
- HotButton
- InventorySlotLinked
- Text
- Mode

Usage:

mq.TLO.Window("BazaarWnd").Child(string.format("BZR_BazaarSlot0")).InvSlot.Selected()