### PR TITLE
Finish DepositItem implementation for Tradeskilldepot window methods

### DIFF
--- a/src/main/datatypes/MQ2TradeskillDepotType.cpp
+++ b/src/main/datatypes/MQ2TradeskillDepotType.cpp
@@ -156,8 +156,7 @@ bool MQ2TradeskillDepotType::GetMember(MQVarPtr VarPtr, const char* Member, char
 				if (pCursorAttachment && pCursorAttachment->Type == eCursorAttachment_Item)
 				{
 					CXPoint pt = pTradeskillDepotWnd->pItemList->GetClientRect().CenterPoint();
-					MoveMouse(pt.x, pt.y);
-					Click(pLocalPlayer, "left");
+					MoveMouse(pt.x, pt.y, true);
 				}
 			}
 #endif

--- a/src/main/datatypes/MQ2TradeskillDepotType.cpp
+++ b/src/main/datatypes/MQ2TradeskillDepotType.cpp
@@ -35,7 +35,7 @@ enum class TradeskillDepotTypeMethods
 	SelectItem,
 	WithdrawItem,
 	WithdrawStack,
-	//DepositItem
+	DepositItem
 };
 
 #if HAS_TRADESKILL_DEPOT
@@ -79,7 +79,7 @@ MQ2TradeskillDepotType::MQ2TradeskillDepotType() : MQ2Type("tradeskilldepot")
 	ScopedTypeMethod(TradeskillDepotTypeMethods, SelectItem);
 	ScopedTypeMethod(TradeskillDepotTypeMethods, WithdrawItem);
 	ScopedTypeMethod(TradeskillDepotTypeMethods, WithdrawStack);
-	//ScopedTypeMethod(TradeskillDepotTypeMethods, DepositItem);
+	ScopedTypeMethod(TradeskillDepotTypeMethods, DepositItem);
 }
 
 bool MQ2TradeskillDepotType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest)
@@ -148,22 +148,22 @@ bool MQ2TradeskillDepotType::GetMember(MQVarPtr VarPtr, const char* Member, char
 			return true;
 		}
 
-//		case TradeskillDepotTypeMethods::DepositItem:
-//		{
-//#if HAS_TRADESKILL_DEPOT
-//			if (pTradeskillDepotWnd->IsVisible() && pActiveBanker)
-//			{
-//				if (pCursorAttachment && pCursorAttachment->Type == eCursorAttachment_Item)
-//				{
-//					CXPoint pt = pTradeskillDepotWnd->pItemList->GetClientRect().CenterPoint();
-//
-//					pTradeskillDepotWnd->pItemList->HandleLButtonDown(pt, 0);
-//					pTradeskillDepotWnd->pItemList->HandleLButtonUp(pt, 0);
-//				}
-//			}
-//#endif
-//			return true;
-//		}
+		case TradeskillDepotTypeMethods::DepositItem:
+		{
+#if HAS_TRADESKILL_DEPOT
+			if (pTradeskillDepotWnd->IsVisible() && pActiveBanker)
+			{
+				if (pCursorAttachment && pCursorAttachment->Type == eCursorAttachment_Item)
+				{
+					CXPoint pt = pTradeskillDepotWnd->pItemList->GetClientRect().CenterPoint();
+					sprintf_s(DataTypeTemp, "%d %d", pt.x, pt.y);
+					MouseTo(pLocalPlayer, DataTypeTemp);
+					Click(pLocalPlayer, "left");
+				}
+			}
+#endif
+			return true;
+		}
 
 		default: break;
 		}

--- a/src/main/datatypes/MQ2TradeskillDepotType.cpp
+++ b/src/main/datatypes/MQ2TradeskillDepotType.cpp
@@ -156,8 +156,7 @@ bool MQ2TradeskillDepotType::GetMember(MQVarPtr VarPtr, const char* Member, char
 				if (pCursorAttachment && pCursorAttachment->Type == eCursorAttachment_Item)
 				{
 					CXPoint pt = pTradeskillDepotWnd->pItemList->GetClientRect().CenterPoint();
-					sprintf_s(DataTypeTemp, "%d %d", pt.x, pt.y);
-					MouseTo(pLocalPlayer, DataTypeTemp);
+					MoveMouse(pt.x, pt.y);
 					Click(pLocalPlayer, "left");
 				}
 			}


### PR DESCRIPTION
Complete the implementation for DepositItem method for TradeskillDepotType

Since using /notify methods on TD_Item_List child results in simply clicking on the center item in the listbox, and simply issuing leftmousedown/up doesn't deposit the item, and the button that captures the deposit of an item isn't available in the xml document to notify, the consensus has been to get the center point, mouseto, then just left click in place. So I've implemented this in the method. 