### PR TITLE
Add old plugin events to lua scripts by convention

### DIFF
--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1763,11 +1763,15 @@ PLUGIN_API void InitializePlugin()
 	s_pluginInterface = new LuaPluginInterfaceImpl();
 
 	bindings::InitializeBindings_MQMacroData();
+	
+	LuaActors::Start();
 }
 
 PLUGIN_API void ShutdownPlugin()
 {
 	using namespace mq::lua;
+	
+	LuaActors::Stop();
 
 	bindings::ShutdownBindings_MQMacroData();
 
@@ -1811,6 +1815,9 @@ PLUGIN_API void OnPulse()
 
 			return false;
 		}), s_running.end());
+	
+	// Process messages after any threads have ended or started (the order likely won't matter since cleanup is checked)
+	LuaActors::Process();
 
 	if (s_infoGC.count() > 0)
 	{


### PR DESCRIPTION
Have a need for some of these plugin events, and this hooks straight into current lua scripts
Had a few different options for implementation but ended on the simpler one which just tries to hook into convention based named global functions in the startup script

Supports following global functions in startup script OnAddSpawn = function (spawn)
OnRemoveSpawn = function (spawn)
OnAddGroundItem= function (groundItem)
OnRemoveGroundItem= function (groundItem)
OnBeginZone= function ()
OnEndZone= function ()
OnZoned= function ()

ie
```lua
local mq = require 'mq'

OnAddSpawn = function (spawn)
    print("Add spawn: "..spawn.ID().." "..spawn.Name())
end

OnRemoveSpawn = function (spawn)
    print("Remove spawn: "..spawn.ID().." "..spawn.Name())
end

OnBeginZone= function (OnBeginZone)
    print("OnBeginZone")
end

while true do
    mq.delay(50)
end
```