### PR TITLE
Use dbstr for expansions and alt currencies

### DIFF
--- a/include/mq/base/String.h
+++ b/include/mq/base/String.h
@@ -312,6 +312,36 @@ inline std::string replace(std::string_view str, std::string_view search, std::s
 	return s;
 }
 
+/**
+ * @fn remove_chars
+ *
+ * @brief Removes specified characters from a string
+ *
+ * Iterates over each character of the input string and constructs a new string by
+ * excluding characters that are found in `chars_to_remove`. This function does not modify the 
+ * original string but returns a new string with the specified characters removed.
+ *
+ * @param str The input string from which characters are to be removed
+ * @param chars_to_remove A string containing characters that should be removed from `str`
+ *
+ * @return std::string A new string with the specified characters removed
+ *
+ **/
+inline std::string remove_chars(std::string_view str, std::string_view chars_to_remove) {
+	std::string result;
+	result.reserve(str.size());
+
+	for (const char ch : str)
+	{
+		if (chars_to_remove.find(ch) == std::string_view::npos)
+		{
+			result += ch;
+		}
+	}
+
+	return result;
+}
+
 // helper function that calls replace with the normal command line argument
 // escape sequences
 inline std::string unescape_args(std::string_view str) {

--- a/src/main/MQ2Globals.cpp
+++ b/src/main/MQ2Globals.cpp
@@ -471,6 +471,7 @@ const char* szInnates[] = {
 	nullptr
 };
 
+[[deprecated("Use GetZoneExpansionName or GetExpansionNumber")]]
 const char* szZoneExpansionName[] = {
 	"Original EQ",              // 0
 	"Kunark",                   // 1
@@ -502,13 +503,15 @@ const char* szZoneExpansionName[] = {
 	"Claws of Veeshan",         // 27
 	"Terror of Luclin",         // 28
 	"Night of Shadows",         // 29
+	"Laurion's Song",           // 30
 };
 
 const char* GetZoneExpansionName(int expansion)
 {
-	if (expansion >= 0 && expansion < (int)lengthof(szZoneExpansionName))
+	if (expansion >= 0 && expansion <= NUM_EXPANSIONS)
 	{
-		return szZoneExpansionName[expansion];
+		if (const char* ptr = pCDBStr->GetString(expansion, eExpansionName, nullptr))
+			return ptr;
 	}
 
 	return "Unknown";
@@ -516,13 +519,11 @@ const char* GetZoneExpansionName(int expansion)
 
 uint32_t GetExpansionNumber(std::string_view expansionName)
 {
-	if (ci_equals(expansionName, "EverQuest"))
-		return 0;
-
-	for (uint32_t i = 0; i < lengthof(szZoneExpansionName); ++i)
+	for (int i = 0; i <= NUM_EXPANSIONS; ++i)
 	{
-		if (ci_equals(szZoneExpansionName[i], expansionName))
-			return i;
+		if (const char* ptr = pCDBStr->GetString(i, eExpansionName, nullptr))
+			if (ci_equals(ptr, expansionName))
+				return i;
 	}
 
 	return 0;

--- a/src/main/MQ2Main.h
+++ b/src/main/MQ2Main.h
@@ -263,7 +263,7 @@ MQLIB_API int FindInvSlot(const char* Name, bool Exact);
 MQLIB_API int FindNextInvSlot(const char* Name, bool Exact);
 
 MQLIB_API int GetLanguageIDByName(const char* szName);
-MQLIB_API int GetCurrencyIDByName(char* szName);
+MQLIB_API int GetCurrencyIDByName(const char* szName);
 MQLIB_API const char* GetSpellNameByID(int dwSpellID);
 MQLIB_API EQ_Spell* GetSpellByName(std::string_view name);
 MQLIB_API EQ_Spell* GetSpellByAAName(const char* szName);

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -1310,58 +1310,31 @@ int GetLanguageIDByName(const char* szName)
 	return -1;
 }
 
-// TOOD: Convert to data table
-int GetCurrencyIDByName(char* szName)
+int GetCurrencyIDByName(const char* szName)
 {
-	if (!_stricmp(szName, "Doubloons")) return ALTCURRENCY_DOUBLOONS;
-	if (!_stricmp(szName, "Orux")) return ALTCURRENCY_ORUX;
-	if (!_stricmp(szName, "Phosphenes")) return ALTCURRENCY_PHOSPHENES;
-	if (!_stricmp(szName, "Phosphites")) return ALTCURRENCY_PHOSPHITES;
-	if (!_stricmp(szName, "Faycitum")) return ALTCURRENCY_FAYCITES;
-	if (!_stricmp(szName, "Chronobines")) return ALTCURRENCY_CHRONOBINES;
-	if (!_stricmp(szName, "Silver Tokens")) return ALTCURRENCY_SILVERTOKENS;
-	if (!_stricmp(szName, "Gold Tokens")) return ALTCURRENCY_GOLDTOKENS;
-	if (!_stricmp(szName, "McKenzie's Special Brew")) return ALTCURRENCY_MCKENZIE;
-	if (!_stricmp(szName, "Bayle Marks")) return ALTCURRENCY_BAYLE;
-	if (!_stricmp(szName, "Tokens of Reclamation")) return ALTCURRENCY_RECLAMATION;
-	if (!_stricmp(szName, "Brellium Tokens")) return ALTCURRENCY_BRELLIUM;
-	if (!_stricmp(szName, "Dream Motes")) return ALTCURRENCY_MOTES;
-	if (!_stricmp(szName, "Rebellion Chits")) return ALTCURRENCY_REBELLIONCHITS;
-	if (!_stricmp(szName, "Diamond Coins")) return ALTCURRENCY_DIAMONDCOINS;
-	if (!_stricmp(szName, "Bronze Fiats")) return ALTCURRENCY_BRONZEFIATS;
-	if (!_stricmp(szName, "Expedient Delivery Vouchers")) return ALTCURRENCY_VOUCHER;
-	if (!_stricmp(szName, "Velium Shards")) return ALTCURRENCY_VELIUMSHARDS;
-	if (!_stricmp(szName, "Crystallized Fear")) return ALTCURRENCY_CRYSTALLIZEDFEAR;
-	if (!_stricmp(szName, "Shadowstones")) return ALTCURRENCY_SHADOWSTONES;
-	if (!_stricmp(szName, "Dreadstones")) return ALTCURRENCY_DREADSTONES;
-	if (!_stricmp(szName, "Marks of Valor")) return ALTCURRENCY_MARKSOFVALOR;
-	if (!_stricmp(szName, "Medals of Heroism")) return ALTCURRENCY_MEDALSOFHEROISM;
-	if (!_stricmp(szName, "Commemorative Coins")) return ALTCURRENCY_COMMEMORATIVE_COINS;
-	if (!_stricmp(szName, "Fists of Bayle")) return ALTCURRENCY_FISTSOFBAYLE;
-	if (!_stricmp(szName, "Nobles")) return ALTCURRENCY_NOBLES;
-	if (!_stricmp(szName, "Arx Energy Crystals")) return ALTCURRENCY_ENERGYCRYSTALS;
-	if (!_stricmp(szName, "Pieces of Eight")) return ALTCURRENCY_PIECESOFEIGHT;
-	if (!_stricmp(szName, "Remnants of Tranquility")) return ALTCURRENCY_REMNANTSOFTRANQUILITY;
-	if (!_stricmp(szName, "Bifurcated Coin")) return ALTCURRENCY_BIFURCATEDCOIN;
-	if (!_stricmp(szName, "Adoptive Coins")) return ALTCURRENCY_ADOPTIVE;
-	if (!_stricmp(szName, "Sathir's Trade Gems")) return ALTCURRENCY_SATHIRSTRADEGEMS;
-	if (!_stricmp(szName, "Ancient Sebilisian Coins")) return ALTCURRENCY_ANCIENTSEBILISIANCOINS;
-	if (!_stricmp(szName, "Bathezid Trade Gems")) return ALTCURRENCY_BATHEZIDTRADEGEMS;
-	if (!_stricmp(szName, "Ancient Draconic Coin")) return ALTCURRENCY_ANCIENTDRACONICCOIN;
-	if (!_stricmp(szName, "Fetterred Ifrit Coins")) return ALTCURRENCY_FETTERREDIFRITCOINS;
-	if (!_stricmp(szName, "Entwined Djinn Coins")) return ALTCURRENCY_ENTWINEDDJINNCOINS;
-	if (!_stricmp(szName, "Crystallized Luck")) return ALTCURRENCY_CRYSTALLIZEDLUCK;
-	if (!_stricmp(szName, "Froststone Ducat")) return ALTCURRENCY_FROSTSTONEDUCAT;
-	if (!_stricmp(szName, "Warlord's Symbol")) return ALTCURRENCY_WARLORDSSYMBOL;
-	if (!_stricmp(szName, "Overseer Tetradrachm")) return ALTCURRENCY_OVERSEERTETRADRACHM;
-	if (!_stricmp(szName, "Restless Mark")) return ALTCURRENCY_RESTLESSMARK;
-	if (!_stricmp(szName, "Warforged Emblem")) return ALTCURRENCY_WARFORGEDEMBLEM;
-	if (!_stricmp(szName, "Scarlet Marks")) return ALTCURRENCY_SCARLETMARKS;
-	if (!_stricmp(szName, "Medals of Conflict")) return ALTCURRENCY_MEDALSOFCONFLICT;
-	if (!_stricmp(szName, "Shaded Specie")) return ALTCURRENCY_SHADEDSPECIE;
-	if (!_stricmp(szName, "Spiritual Medallion")) return ALTCURRENCY_SPIRITUALMEDALLION;
-	if (!_stricmp(szName, "Laurion Inn Voucher")) return ALTCURRENCY_LAURIONINNVOUCHER;
-	if (!_stricmp(szName, "Shalowains Private Reserve")) return ALTCURRENCY_SHALOWAINSPRIVATERESERVE;
+	constexpr std::string_view chars_to_remove = "'`";
+	const std::string currency = remove_chars(szName, chars_to_remove);
+	for (int i = ALTCURRENCY_FIRST; i <= ALTCURRENCY_LAST; ++i)
+	{
+		// Check the plural form first
+		if (const char* currency_name_plural = pCDBStr->GetString(i, eAltCurrencyNamePlural))
+		{
+			if (ci_equals(currency, remove_chars(currency_name_plural, chars_to_remove)))
+				return i;
+
+			// Then check the singular form
+			if (const char* currency_name_singular = pCDBStr->GetString(i, eAltCurrencyName))
+			{
+				if (ci_equals(currency, remove_chars(currency_name_singular, chars_to_remove)))
+					return i;
+			}
+		}
+	}
+
+	// Crowns sit outside the ALTCURRENCY_MAX range
+	if (ci_equals(currency, "Crowns") || ci_equals(currency, "Crown"))
+		return ALTCURRENCY_CROWNS;
+
 	return -1;
 }
 

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -1331,7 +1331,7 @@ int GetCurrencyIDByName(const char* szName)
 		}
 	}
 
-	// Crowns sit outside the ALTCURRENCY_MAX range
+	// Crowns sit outside the ALTCURRENCY_LAST range
 	if (ci_equals(currency, "Crowns") || ci_equals(currency, "Crown"))
 		return ALTCURRENCY_CROWNS;
 

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -1312,6 +1312,13 @@ int GetLanguageIDByName(const char* szName)
 
 int GetCurrencyIDByName(const char* szName)
 {
+	static std::unordered_map<std::string, int> cache;
+
+	const auto it = cache.find(szName);
+	if (it != cache.end()) {
+		return it->second;
+	}
+
 	constexpr std::string_view chars_to_remove = "'`";
 	const std::string currency = remove_chars(szName, chars_to_remove);
 	for (int i = ALTCURRENCY_FIRST; i <= ALTCURRENCY_LAST; ++i)
@@ -1320,21 +1327,31 @@ int GetCurrencyIDByName(const char* szName)
 		if (const char* currency_name_plural = pCDBStr->GetString(i, eAltCurrencyNamePlural))
 		{
 			if (ci_equals(currency, remove_chars(currency_name_plural, chars_to_remove)))
+			{
+				cache[szName] = i;
 				return i;
+			}
 
 			// Then check the singular form
 			if (const char* currency_name_singular = pCDBStr->GetString(i, eAltCurrencyName))
 			{
 				if (ci_equals(currency, remove_chars(currency_name_singular, chars_to_remove)))
+				{
+					cache[szName] = i;
 					return i;
+				}
 			}
 		}
 	}
 
 	// Crowns sit outside the ALTCURRENCY_LAST range
 	if (ci_equals(currency, "Crowns") || ci_equals(currency, "Crown"))
+	{
+		cache[szName] = ALTCURRENCY_CROWNS;
 		return ALTCURRENCY_CROWNS;
+	}
 
+	cache[szName] = -1;
 	return -1;
 }
 

--- a/src/main/datatypes/MQ2CharacterType.cpp
+++ b/src/main/datatypes/MQ2CharacterType.cpp
@@ -3456,6 +3456,7 @@ bool MQ2CharacterType::GetMember(MQVarPtr VarPtr, const char* Member, char* Inde
 		return true;
 
 	case CharacterMembers::AltCurrency:
+	{
 		Dest.DWord = 0;
 		Dest.Type = pIntType;
 
@@ -3467,15 +3468,13 @@ bool MQ2CharacterType::GetMember(MQVarPtr VarPtr, const char* Member, char* Inde
 			Dest.DWord = pPlayerPointManager->GetAltCurrency(GetIntFromString(Index, 0));
 			return true;
 		}
-		else
-		{
-			int nCurrency = GetCurrencyIDByName(Index);
-			if (nCurrency < 0)
-				return false;
-			Dest.DWord = pPlayerPointManager->GetAltCurrency(nCurrency);
-			return true;
-		}
-		return false;
+
+		int nCurrency = GetCurrencyIDByName(Index);
+		if (nCurrency < 0)
+			return false;
+		Dest.DWord = pPlayerPointManager->GetAltCurrency(nCurrency);
+		return true;
+	}
 
 	case CharacterMembers::Slowed:
 		Dest.Type = pBuffType;


### PR DESCRIPTION
- Add remove_chars for removing specific characters in a string
- Deprecate szZoneExpansionName (and update for Laurion's Song)
- Update GetZoneExpansionX to use dbstr for expansions
- Update Alternate Currency Enums to match dbstr consistently
- Modify GetCurrencyIDByName to use dbstr for alt currencies -- this will allow for mq.TLO.Me.AltCurrency('<name>')() to work with the singular or plural name of the currency.  Additionally, it will match regardless of apostrophe or backtick to be compatible with previous changes