### PR TITLE
Ability work

### DIFF
--- a/include/mq/api/Abilities.h
+++ b/include/mq/api/Abilities.h
@@ -1,0 +1,200 @@
+/*
+ * MacroQuest: The extension platform for EverQuest
+ * Copyright (C) 2002-2023 MacroQuest Authors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "eqlib/Globals.h"
+
+using namespace eqlib;
+
+namespace mq {
+
+/**
+ * @fn GetAdjustedSkill
+ *
+ * @brief Retrieves the adjusted skill level for a given skill
+ *
+ * Returns the total skill level for a given skill, including
+ * any bonuses from items, spells, or other sources.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return int The adjusted skill level or 0 if pLocalPC is not available.
+ **/
+MQLIB_API int GetAdjustedSkill(int nSkill);
+
+/**
+ * @fn GetBaseSkill
+ *
+ * @brief Retrieves the base skill level for a given skill
+ *
+ * Returns the base skill level for a given skill, before
+ * any bonuses from items, spells, or adjustments.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return int The base skill level or 0 if pLocalPC is not available.
+ **/
+MQLIB_API int GetBaseSkill(int nSkill);
+
+/**
+ * @fn HasSkill
+ *
+ * @brief Checks if the character has a specific skill
+ *
+ * Returns whether the character has a specific skill. Does not
+ * work for innate skills.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return bool True if the character has the specified skill, false otherwise
+ **/
+MQLIB_API bool HasSkill(int nSkill);
+
+/**
+ * @fn SkillIsActivatable
+ *
+ * @brief Checks if the skill is activatable
+ *
+ * Returns whether the skill is activatable. An activatable skill
+ * is also known as an Ability. Does not include innate skills.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return bool True if the skill is activatable, false otherwise
+ **/
+MQLIB_API bool SkillIsActivatable(int nSkill);
+
+/**
+ * @fn HasInnateSkill
+ *
+ * @brief Checks if the character has a specific innate skill
+ *
+ * Returns whether the character has a specific innate skill. Does not
+ * work for non-innate skills. Innate skills can be specified as either
+ * their actual number or the "stacked" number.
+ *
+ * For example, slam is identified by both 111 and 11.
+ *
+ * @param nSkill The innate skill identifier (either version)
+ *
+ * @return bool True if the character has the specified innate skill, false otherwise
+ **/
+MQLIB_API bool HasInnateSkill(int nSkill);
+
+/**
+ * @fn InnateSkillIsActivatable
+ *
+ * @brief Checks if the innate skill is activatable
+ *
+ * Returns whether the innate skill is activatable. An activatable skill
+ * is also known as an Ability. Does not work for non-innate skills.
+ * Innate skills can be specified as either their actual number or the
+ * "stacked" number.
+ *
+ * @param nSkill The innate skill identifier (either version)
+ *
+ * @return bool True if the innate skill is activatable, false otherwise
+ **/
+MQLIB_API bool InnateSkillIsActivatable(int nSkill);
+
+/**
+ * @fn HasSkillOrInnate
+ *
+ * @brief Checks if the character has a specific skill
+ *
+ * Returns whether the character has a specific skill. This includes
+ * innate skills, but innate skills must be specified as their "stacked"
+ * (above 100) number.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return bool True if the character has the specified skill, false otherwise
+ **/
+MQLIB_API bool HasSkillOrInnate(int nSkill);
+
+/**
+ * @fn SkillOrInnateIsActivatable
+ *
+ * @brief Checks if the skill is activatable
+ *
+ * Returns whether the skill is activatable. An activatable skill
+ * is also known as an Ability. This includes innate skills, but
+ * innate skills must be specified as their "stacked" (above 100)
+ * number.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return bool True if the skill is activatable, false otherwise
+ **/
+MQLIB_API bool SkillOrInnateIsActivatable(int nSkill);
+
+/**
+ * @fn GetSkillName
+ *
+ * @brief Retrieves the name of a skill based on its identifier
+ *
+ * Returns the name of a skill given its identifier. This includes
+ * innate skills, but innate skills must be specified as their
+ * "stacked" (above 100) number.
+ *
+ * @param nSkill The skill identifier
+ *
+ * @return const char* The name of the skill, or nullptr if an issue
+ **/
+MQLIB_API const char* GetSkillName(int nSkill);
+
+/**
+ * @fn GetSkillIDFromString
+ *
+ * @brief Converts a string to a corresponding skill identifier
+ *
+ * Attempts to convert a string into an skill identifier. If the string
+ * represents a numeric value, it is converted directly to an integer.
+ * If it's a non-numeric string, the function searches for a matching
+ * skill name and returns its identifier.
+ *
+ * For innate abilities, the function will only return the "stacked"
+ * (above 100) value.
+ *
+ * The function returns a default value (iReturnOnFail) if the string is
+ * empty, if no matching skill is found, or if the numeric conversion
+ * results in a value outside the valid range of skill identifiers.
+ *
+ * @param svString The string representing the skill, either as a name or a number
+ * @param iReturnOnFail (Optional) The value to return on failure to convert, defaults to -1
+ *
+ * @return int The skill identifier corresponding to the string, or iReturnOnFail on failure
+ **/
+MQLIB_API int GetSkillIDFromString(std::string_view svString, int iReturnOnFail = -1);
+
+/**
+ * @fn GetAbilityIDFromString
+ *
+ * @brief Converts a string to a corresponding ability identifier
+ *
+ * Attempts to convert a string into an ability identifier using GetSkillIDFromString.
+ * An ability is a skill that can be activated, so if the skill is not activatable,
+ * this will return a failure.
+ *
+ * @see GetSkillIDFromString
+ *
+ * @param svString The string representing the ability, either as a name or a number
+ * @param iReturnOnFail (Optional) The value to return on failure to convert, defaults to -1
+ *
+ * @return int The ability identifier corresponding to the string, or iReturnOnFail on failure
+ **/
+MQLIB_API int GetAbilityIDFromString(std::string_view svString, int iReturnOnFail = -1);
+
+} // namespace mq

--- a/include/mq/api/Abilities.h
+++ b/include/mq/api/Abilities.h
@@ -14,7 +14,8 @@
 
 #pragma once
 
-#include "eqlib/Globals.h"
+#include "eqlib/PcClient.h"
+#include "eqlib/EQClasses.h"
 
 using namespace eqlib;
 
@@ -32,7 +33,10 @@ namespace mq {
  *
  * @return int The adjusted skill level or 0 if pLocalPC is not available.
  **/
-MQLIB_API int GetAdjustedSkill(int nSkill);
+inline int GetAdjustedSkill(int nSkill)
+{
+	return pLocalPC ? pLocalPC->GetAdjustedSkill(nSkill) : 0;
+}
 
 /**
  * @fn GetBaseSkill
@@ -46,7 +50,10 @@ MQLIB_API int GetAdjustedSkill(int nSkill);
  *
  * @return int The base skill level or 0 if pLocalPC is not available.
  **/
-MQLIB_API int GetBaseSkill(int nSkill);
+inline int GetBaseSkill(int nSkill)
+{
+	return pLocalPC ? pLocalPC->GetBaseSkill(nSkill) : 0;
+}
 
 /**
  * @fn HasSkill
@@ -60,7 +67,10 @@ MQLIB_API int GetBaseSkill(int nSkill);
  *
  * @return bool True if the character has the specified skill, false otherwise
  **/
-MQLIB_API bool HasSkill(int nSkill);
+inline bool HasSkill(int nSkill)
+{
+	return pLocalPC && pLocalPC->HasSkill(nSkill);
+}
 
 /**
  * @fn SkillIsActivatable
@@ -74,7 +84,10 @@ MQLIB_API bool HasSkill(int nSkill);
  *
  * @return bool True if the skill is activatable, false otherwise
  **/
-MQLIB_API bool SkillIsActivatable(int nSkill);
+inline bool SkillIsActivatable(int nSkill)
+{
+	return nSkill < NUM_SKILLS && pSkillMgr && pSkillMgr->pSkill[nSkill]->Activated;
+}
 
 /**
  * @fn HasInnateSkill

--- a/include/mq/base/String.h
+++ b/include/mq/base/String.h
@@ -599,6 +599,30 @@ public:
 };
 
 /**
+ * @fn IsNumber
+ *
+ * @brief Checks if a string represents a valid number
+ *
+ * Takes a string view and checks if it can be successfully parsed into a
+ * double precision floating point number.  This is different from the
+ * GetXFromString functions in that the entire string must be a number.
+ *
+ * @param String The string to be evaluated
+ *
+ * @return bool True if the string represents a valid number, false otherwise
+ **/
+inline bool IsNumber(std::string_view String)
+{
+	if (String.empty())
+		return false;
+
+	double test_var;
+	const auto result = std::from_chars(String.data(), String.data() + String.size(), test_var, std::chars_format::fixed);
+
+	return result.ec != std::errc::invalid_argument && result.ptr[0] == '\0';
+}
+
+/**
  * @fn GetIntFromString
  *
  * @brief Gets the int value from a well formatted string

--- a/src/eqdata/skills.h
+++ b/src/eqdata/skills.h
@@ -40,7 +40,7 @@
 	"Feign Death",             // 25
 	"Flying Kick",             // 26
 	"Forage",                  // 27
-	"Hand To Hand",            // 28
+	"Hand to Hand",            // 28
 	"Hide",                    // 29
 	"Kick",                    // 30
 	"Meditate",                // 31
@@ -113,19 +113,19 @@
 	"98",                      // 98
 	"99",                      // 99
 	"100",                     // 100
-	"101",                     // 101
-	"102",                     // 102
-	"103",                     // 103
-	"104",                     // 104
-	"Harm Touch",              // 105
-	"106",                     // 106
-	"Lay Hands",               // 107
-	"108",                     // 108
-	"109",                     // 109
-	"110",                     // 110
+	"Awareness",               // 101
+	"Bash Door",               // 102
+	"Breathe Fire",            // 103
+	"Harmony",                 // 104
+	"Harm Touch",              // 105  Pre-ROF2 clients
+	"Infravision",             // 106
+	"Lay Hands",               // 107  Pre-ROF2 clients
+	"Lore",                    // 108
+	"No Bash",                 // 109
+	"Regeneration",            // 110
 	"Slam",                    // 111
-	"112",                     // 112
-	"113",                     // 113
+	"Surprise",                // 112
+	"Ultravision",             // 113
 	"Inspect",                 // 114
 	"Open",                    // 115
 	"Reveal Trap",             // 116
@@ -136,8 +136,8 @@
 	"121",                     // 121
 	"122",                     // 122
 	"123",                     // 123
-	"124",                     // 124
-	"125",                     // 125
+	"124",                     // 124 // Everything below this line is probably wrong -- the size of Learned skills is 100
+	"125",                     // 125 // While the size of innate skills is 25.  That means 124 should be the max here.
 	"126",                     // 126
 	"127",                     // 127 this should be last one
 	"128",                     // 128 here for compatibility

--- a/src/main/MQ2Commands.cpp
+++ b/src/main/MQ2Commands.cpp
@@ -2671,7 +2671,7 @@ void DoAbility(SPAWNINFO* pChar, char* szLine)
 					}
 					else
 					{
-						WriteChatf("DoAbility: Skill is not activatable (%s)", szBuffer);
+						WriteChatf("/doability: Skill is not activatable (%s)", szBuffer);
 					}
 				}
 				else

--- a/src/main/MQ2Commands.cpp
+++ b/src/main/MQ2Commands.cpp
@@ -2609,6 +2609,7 @@ void DoAbility(SPAWNINFO* pChar, char* szLine)
 {
 	if (!szLine[0] || !cmdDoAbility || !pLocalPC)
 		return;
+
 	if (IsNumber(szLine))
 	{
 		cmdDoAbility(pChar, szLine);
@@ -2616,7 +2617,7 @@ void DoAbility(SPAWNINFO* pChar, char* szLine)
 	}
 
 	char szBuffer[MAX_STRING] = { 0 };
-	GetArg(szBuffer, szLine, 1);
+	GetMaybeQuotedArg(szBuffer, MAX_STRING, szLine, 1);
 
 	PcProfile* pProfile = GetPcProfile();
 	if (!pProfile)
@@ -2628,29 +2629,14 @@ void DoAbility(SPAWNINFO* pChar, char* szLine)
 		WriteChatColor("Abilities & Combat Skills:");
 
 		// display skills that have activated state
-		for (int Index = 0; Index < NUM_SKILLS; Index++)
+		for (int Index = 0; Index < NUM_SKILLS + NUM_INNATE; ++Index)
 		{
-			if (HasSkill(Index))
+			if (HasSkillOrInnate(Index) && SkillOrInnateIsActivatable(Index))
 			{
-				bool Avail = pSkillMgr->pSkill[Index]->Activated;
-
-				// make sure remove trap is added, they give it to everyone except rogues
-				if (Index == 75 && strncmp(pEverQuest->GetClassDesc(pProfile->Class & 0xFF), "Rogue", 6))
-					Avail = true;
-
-				if (Avail)
+				if (const char* skill_name = GetSkillName(Index))
 				{
-					WriteChatf("<\ag%s\ax>", szSkills[Index]);
+					WriteChatf("<\ag%s\ax>", skill_name);
 				}
-			}
-		}
-
-		// display innate skills that are available
-		for (int Index = 0; Index < 28; Index++)
-		{
-			if (pProfile->InnateSkill[Index] != 0xFF && strlen(szSkills[Index + 100]) > 3)
-			{
-				WriteChatf("<\ag%s\ax>", szSkills[Index + 100]);
 			}
 		}
 
@@ -2670,41 +2656,28 @@ void DoAbility(SPAWNINFO* pChar, char* szLine)
 		return;
 	}
 
-	int abilityNum = GetIntFromString(szBuffer, 0);
-	if (abilityNum > 0)
-	{
-		// Check if user wants us to activate an ability by its "real id" (?)
-		if (abilityNum > 6 && abilityNum < NUM_SKILLS)
-		{
-			int token = pSkillMgr->GetNameToken(abilityNum);
-			if (token != 0)
-			{
-				strcpy_s(szBuffer, pStringTable->getString(token));
-			}
-		}
-		else
-		{
-			// passthrough to original function
-			cmdDoAbility(pChar, szLine);
-			return;
-		}
-	}
-
 	// scan for matching abilities name
-	for (int Index = 0; Index < 128; Index++)
+	for (int Index = 0; Index < NUM_SKILLS + NUM_INNATE; ++Index)
 	{
-		if (Index < NUM_SKILLS && pSkillMgr->pSkill[Index]->Activated
-			|| Index > NUM_SKILLS && pProfile->InnateSkill[Index - 100] != 0xFF)
+		if (const char* skill_name = GetSkillName(Index))
 		{
-			if (!_stricmp(szBuffer, szSkills[Index]))
+			if (ci_equals(szBuffer, skill_name))
 			{
-				if (!HasSkill(Index))
+				if (HasSkillOrInnate(Index))
 				{
-					WriteChatf("you do not have this skill (%s)", szBuffer);
-					return;
+					if (SkillOrInnateIsActivatable(Index))
+					{
+						pLocalPC->UseSkill(static_cast<uint8_t>(Index), pLocalPlayer);
+					}
+					else
+					{
+						WriteChatf("DoAbility: Skill is not activatable (%s)", szBuffer);
+					}
 				}
-
-				pLocalPC->UseSkill(static_cast<uint8_t>(Index), pLocalPlayer);
+				else
+				{
+					WriteChatf("You do not have this skill (%s)", szBuffer);
+				}
 				return;
 			}
 		}
@@ -2726,11 +2699,7 @@ void DoAbility(SPAWNINFO* pChar, char* szLine)
 		}
 	}
 
-	// else display that we didnt found abilities
-	if (abilityNum)
-		WriteChatf("You do not seem to have ability %s (%d) available", szBuffer, abilityNum);
-	else
-		WriteChatf("You do not seem to have ability %s available", szBuffer);
+	WriteChatf("You do not seem to have ability %s available", szBuffer);
 }
 
 // ***************************************************************************

--- a/src/main/MQ2Globals.cpp
+++ b/src/main/MQ2Globals.cpp
@@ -453,22 +453,31 @@ const char* szSkills[] = {
 };
 
 const char* szInnates[] = {
-	"Awareness",//c4c
-	"Bash Door",//c50
-	"Breathe Fire",//c54
-	"Harmony",//c58
-	"Harm Touch",//c5c
-	"Infravision",//c60
-	"Lay Hands",//c64
-	"Lore",//c68
-	"No Bash",//c6c
-	"Regeneration",//c70
-	"Slam",//c74
-	"Surprise",//c78
-	"Ultravision",//c7c
-	"Inspect",//c80
-	"Open",//c84
-	nullptr
+	nullptr,          // 0
+	"Awareness",      // 1
+	"Bash Door",      // 2
+	"Breathe Fire",   // 3
+	"Harmony",        // 4
+	"Harm Touch",     // 5
+	"Infravision",    // 6
+	"Lay Hands",      // 7
+	"Lore",           // 8
+	"No Bash",        // 9
+	"Regeneration",   // 10
+	"Slam",           // 11
+	"Surprise",       // 12
+	"Ultravision",    // 13
+	"Inspect",        // 14
+	"Open",           // 15
+	"Reveal Trap",    // 16
+	nullptr,          // 17
+	nullptr,          // 18
+	nullptr,          // 19
+	nullptr,          // 20
+	nullptr,          // 21
+	nullptr,          // 22
+	nullptr,          // 23
+	nullptr,          // 24
 };
 
 [[deprecated("Use GetZoneExpansionName or GetExpansionNumber")]]

--- a/src/main/MQ2Inlines.h
+++ b/src/main/MQ2Inlines.h
@@ -17,6 +17,7 @@
 #include "../common/Common.h"
 
 #include "mq/api/Spawns.h"
+#include "mq/api/Abilities.h"
 
  // string trim includes:
 #include <algorithm>
@@ -217,16 +218,6 @@ inline int GetMaxMana()
 	return pLocalPC ? pLocalPC->Max_Mana() : 0;
 }
 
-inline int GetAdjustedSkill(int nSkill)
-{
-	return pLocalPC ? pLocalPC->GetAdjustedSkill(nSkill) : 0;
-}
-
-inline int GetBaseSkill(int nSkill)
-{
-	return pLocalPC ? pLocalPC->GetBaseSkill(nSkill) : 0;
-}
-
 inline int GetModCap(int index, bool bToggle = false)
 {
 	return pLocalPC ? pLocalPC->GetModCap(index, bToggle) : 0;
@@ -245,11 +236,6 @@ inline int GetFocusCastingTimeModifier(const EQ_Spell* pSpell, ItemPtr& pItemOut
 inline int GetFocusRangeModifier(const EQ_Spell* pSpell, ItemPtr& pItemOut)
 {
 	return pLocalPC ? pLocalPC->GetFocusRangeModifier(pSpell, pItemOut) : 0;
-}
-
-inline bool HasSkill(int nSkill)
-{
-	return pLocalPC && pLocalPC->HasSkill(nSkill);
 }
 
 inline float GetDistance(float X1, float Y1)
@@ -385,17 +371,6 @@ inline uint32_t ConColorToARGB(int ConColor)
 	default:
 		return 0xFFFF0000;
 	}
-}
-
-inline bool IsNumber(std::string_view String)
-{
-	if (String.empty())
-		return false;
-
-	double test_var;
-	const auto result = std::from_chars(String.data(), String.data() + String.size(), test_var, std::chars_format::fixed);
-
-	return result.ec != std::errc::invalid_argument && result.ptr[0] == '\0';
 }
 
 inline bool IsNumberToComma(const char* String)

--- a/src/main/MQ2Main.vcxproj
+++ b/src/main/MQ2Main.vcxproj
@@ -157,6 +157,7 @@
       <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">pch.h</ForcedIncludeFiles>
       <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|x64'">pch.h</ForcedIncludeFiles>
     </ClCompile>
+    <ClCompile Include="api\Abilities.cpp" />
     <ClCompile Include="api\Spawns.cpp" />
     <ClCompile Include="datatypes\MQ2AchievementType.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -561,6 +562,7 @@
     <ClInclude Include="..\..\contrib\tinyfsm\include\tinyfsm.hpp" />
     <ClInclude Include="..\..\include\extras\wil\Constants.h" />
     <ClInclude Include="..\..\include\moveitem.h" />
+    <ClInclude Include="..\..\include\mq\api\Abilities.h" />
     <ClInclude Include="..\..\include\mq\api\Achievements.h" />
     <ClInclude Include="..\..\include\mq\api\ActorAPI.h" />
     <ClInclude Include="..\..\include\mq\api\Inventory.h" />

--- a/src/main/MQ2Main.vcxproj.filters
+++ b/src/main/MQ2Main.vcxproj.filters
@@ -401,6 +401,9 @@
     <ClCompile Include="datatypes\MQCursorAttachmentType.cpp">
       <Filter>Source Files\datatypes</Filter>
     </ClCompile>
+    <ClCompile Include="api\Abilities.cpp">
+      <Filter>Source Files\api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MQ2Commands.h">
@@ -636,6 +639,9 @@
     </ClInclude>
     <ClInclude Include="..\eqdata\spelleffects.h">
       <Filter>Header Files\eqdata</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\mq\api\Abilities.h">
+      <Filter>Header Files\mq\api</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/main/api/Abilities.cpp
+++ b/src/main/api/Abilities.cpp
@@ -16,36 +16,16 @@
 
 #include "mq/api/Abilities.h"
 
-#include "eqlib/PcClient.h"
-#include "eqlib/EQClasses.h"
+namespace mq {
 
 // Defined in MQ2Globals.cpp but we don't want to bring in all of MQ2Globals.h
 MQLIB_VAR const char* szInnates[];
 
-namespace mq {
-
-int GetAdjustedSkill(int nSkill)
-{
-	return pLocalPC ? pLocalPC->GetAdjustedSkill(nSkill) : 0;
-}
-
-int GetBaseSkill(int nSkill)
-{
-	return pLocalPC ? pLocalPC->GetBaseSkill(nSkill) : 0;
-}
-
-bool HasSkill(int nSkill)
-{
-	return pLocalPC && pLocalPC->HasSkill(nSkill);
-}
-
-bool SkillIsActivatable(int nSkill)
-{
-	return nSkill < NUM_SKILLS && pSkillMgr && pSkillMgr->pSkill[nSkill]->Activated;
-}
-
 bool HasInnateSkill(int nSkill)
 {
+	if (pLocalPC == nullptr)
+		return false;
+
 	// Innate skills stack on top of normal skills when used with Skill Manager
 	// Allow for both
 	if (nSkill >= NUM_SKILLS)
@@ -54,9 +34,8 @@ bool HasInnateSkill(int nSkill)
 	if (nSkill < 0 || nSkill > NUM_INNATE)
 		return false;
 
-	const PcProfile* pProfile = pLocalPC ? pLocalPC->GetCurrentPcProfile() : nullptr;
 	// 255 is the default value for an unset innate skill
-	return 	pProfile && pProfile->InnateSkill[nSkill] != 255;
+	return pLocalPC->GetCurrentPcProfile()->InnateSkill[nSkill] != 255;
 }
 
 bool InnateSkillIsActivatable(int nSkill)

--- a/src/main/api/Abilities.cpp
+++ b/src/main/api/Abilities.cpp
@@ -1,0 +1,141 @@
+/*
+ * MacroQuest: The extension platform for EverQuest
+ * Copyright (C) 2002-2023 MacroQuest Authors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "pch.h"
+
+#include "mq/api/Abilities.h"
+
+#include "eqlib/PcClient.h"
+#include "eqlib/EQClasses.h"
+
+// Defined in MQ2Globals.cpp but we don't want to bring in all of MQ2Globals.h
+MQLIB_VAR const char* szInnates[];
+
+namespace mq {
+
+int GetAdjustedSkill(int nSkill)
+{
+	return pLocalPC ? pLocalPC->GetAdjustedSkill(nSkill) : 0;
+}
+
+int GetBaseSkill(int nSkill)
+{
+	return pLocalPC ? pLocalPC->GetBaseSkill(nSkill) : 0;
+}
+
+bool HasSkill(int nSkill)
+{
+	return pLocalPC && pLocalPC->HasSkill(nSkill);
+}
+
+bool SkillIsActivatable(int nSkill)
+{
+	return nSkill < NUM_SKILLS && pSkillMgr && pSkillMgr->pSkill[nSkill]->Activated;
+}
+
+bool HasInnateSkill(int nSkill)
+{
+	// Innate skills stack on top of normal skills when used with Skill Manager
+	// Allow for both
+	if (nSkill >= NUM_SKILLS)
+		nSkill -= NUM_SKILLS;
+
+	if (nSkill < 0 || nSkill > NUM_INNATE)
+		return false;
+
+	const PcProfile* pProfile = pLocalPC ? pLocalPC->GetCurrentPcProfile() : nullptr;
+	// 255 is the default value for an unset innate skill
+	return 	pProfile && pProfile->InnateSkill[nSkill] != 255;
+}
+
+bool InnateSkillIsActivatable(int nSkill)
+{
+	if (nSkill < NUM_SKILLS)
+		nSkill += NUM_SKILLS;
+	//              slam            inspect          open        reveal trap
+	return nSkill == 111 || nSkill == 114 || nSkill == 115 || nSkill == 116;
+}
+
+bool HasSkillOrInnate(int nSkill)
+{
+	if (nSkill < 0 || nSkill >= NUM_SKILLS + NUM_INNATE)
+		return false;
+
+	if (nSkill < NUM_SKILLS)
+		return HasSkill(nSkill);
+	return HasInnateSkill(nSkill);
+}
+
+bool SkillOrInnateIsActivatable(int nSkill)
+{
+	if (nSkill < 0 || nSkill >= NUM_SKILLS + NUM_INNATE)
+		return false;
+
+	if (nSkill < NUM_SKILLS)
+		return SkillIsActivatable(nSkill);
+	return InnateSkillIsActivatable(nSkill);
+}
+
+const char* GetSkillName(int nSkill)
+{
+	if (nSkill < 0 || nSkill >= NUM_SKILLS + NUM_INNATE)
+		return nullptr;
+
+	if (nSkill < NUM_SKILLS)
+		return pStringTable && pSkillMgr ? pStringTable->getString(pSkillMgr->GetNameToken(nSkill)) : nullptr;
+
+	return szInnates[nSkill - 100];
+}
+
+int GetSkillIDFromString(std::string_view svString, int iReturnOnFail /* = -1 */)
+{
+	if (svString.empty())
+		return iReturnOnFail;
+
+	int nSkill = iReturnOnFail;
+	if (IsNumber(svString))
+	{
+		nSkill = GetIntFromString(svString, iReturnOnFail);
+	}
+	else
+	{
+		// Search by Name
+		for (int i = 0; i < NUM_SKILLS + NUM_INNATE; ++i)
+		{
+			if (const char* skill_name = GetSkillName(i))
+			{
+				if (ci_equals(svString, skill_name))
+				{
+					nSkill = i;
+					break;
+				}
+			}
+		}
+	}
+
+	if (nSkill < 0 || nSkill >= NUM_SKILLS + NUM_INNATE)
+		nSkill = iReturnOnFail;
+
+	return nSkill;
+}
+
+int GetAbilityIDFromString(std::string_view svString, int iReturnOnFail /* = -1 */)
+{
+	int nSkill = GetSkillIDFromString(svString, iReturnOnFail);
+	if (!SkillOrInnateIsActivatable(nSkill))
+		nSkill = iReturnOnFail;
+	return nSkill;
+}
+
+} // namespace mq


### PR DESCRIPTION
- Move IsNumber to strings.h
- Update skills.h with innate skill names
- Update szInnates with appropriate data
- Split Ability functions into their own files and add documentation User Facing:
- /doability will now accept quoted or unquoted ability names
- /doability will now work for innate skills (Fixes #371)
- mq.TLO.Me.Ability is now a boolean. It returns true or false based on whether you have the ability.
- mq.TLO.Me.AbilityReady will no longer say an ability is ready if you don't have that ability.
- Added mq.TLO.Me.AbilityTimerTotal which will return the total amount of time an ability takes to refresh. This is only available while the ability is in cooldown, otherwise it returns 0. Useful for converting mq.TLO.Me.AbilityTimer into a percentage.  (Supersedes #823)