### PR TITLE
Remove open on arrow flag for treepanel

### DIFF
--- a/src/imgui/ImGuiTreePanelWindow.h
+++ b/src/imgui/ImGuiTreePanelWindow.h
@@ -244,7 +244,7 @@ private:
 
 	void DrawTreeNode(PanelTreeNode* node)
 	{
-		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanFullWidth;
+		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanFullWidth;
 		bool isLeaf = node->children.empty();
 
 		if (node->def != nullptr && (m_selectedPanel == nullptr || node->def->selectRequested))


### PR DESCRIPTION
ImGuiTreeNodeFlags_OpenOnArrow  means that you may only click on the arrow to expand the tree, instead of being able to click anywhere on the text of the treenode. The entire treenode value highlights as selectable, suggesting you can click anywhere, but you can't because of the flag.

Impacts at least the MQ settings window and the autologin window.