### PR TITLE
Add support for rendering the EQ cursor with ImGui

### DIFF
--- a/contrib/imgui/imconfig.h
+++ b/contrib/imgui/imconfig.h
@@ -24,6 +24,7 @@
 #if HAS_DIRECTX_11
 #include <d3d11.h>
 #endif
+#include <type_traits>
 
 //---- Define assertion handler. Defaults to calling assert().
 // If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.
@@ -125,6 +126,11 @@ public:
         operator MyVec4() const { return MyVec4(x,y,z,w); }
 */
 
+#define IM_VEC2_CLASS_EXTRA \
+    template <typename T, typename U, typename = std::enable_if_t<std::conjunction_v<      \
+        std::is_arithmetic_v<T>, std::is_arithmetic_v<U>>>> \
+    constexpr ImVec2(T x_, U y_) : x(static_cast<float>(x_)), y(static_cast<float>(y_)) {}
+
 #define IM_VEC4_CLASS_EXTRA \
     static ImVec4 FromImU32(ImU32 u32); \
     ImU32 ToImU32() const;
@@ -167,6 +173,17 @@ namespace eqlib
 
 #if HAS_DIRECTX_11
 
+namespace eqlib
+{
+    inline namespace DX9Wrapper {
+        namespace DX11 {
+            class TextureImpl;
+        }
+    }
+
+    using Direct3DTexture9 = DX9Wrapper::DX11::TextureImpl;
+}
+
 class ImGuiTextureObject
 {
 public:
@@ -187,6 +204,11 @@ public:
     ImGuiTextureObject(const eqlib::CEQGBitmap* bitmap)
     {
         SetBitmap(bitmap);
+    }
+
+    ImGuiTextureObject(const eqlib::Direct3DTexture9* texture)
+    {
+        SetTexture(texture);
     }
 
     ImGuiTextureObject(const ImGuiTextureObject& other)
@@ -226,6 +248,13 @@ public:
         return *this;
     }
 
+    ImGuiTextureObject& operator=(const eqlib::Direct3DTexture9* texture)
+    {
+        SetTexture(texture);
+
+        return *this;
+    }
+
     ImGuiTextureObject& operator=(ID3D11ShaderResourceView* shaderResourceView)
     {
         SetPointer(shaderResourceView);
@@ -240,7 +269,9 @@ public:
         return *this;
     }
 
-    bool IsBitmap() const { return (value & 0x8000000000000000) != 0; }
+    bool IsBitmap() const { return (value & 0xC000000000000000) == 0x8000000000000000; }
+    bool IsTexture() const { return (value & 0xC000000000000000) == 0xC000000000000000; }
+    bool IsSRV() const { return (value & 0xC000000000000000) == 0x0000000000000000; }
 
     const eqlib::CEQGBitmap* GetBitmap() const
     {
@@ -248,7 +279,11 @@ public:
     }
     ID3D11ShaderResourceView* GetShaderResourceView() const
     {
-        return IsBitmap() ? nullptr : static_cast<ID3D11ShaderResourceView*>(GetPointer());
+        return IsSRV() ? static_cast<ID3D11ShaderResourceView*>(GetPointer()) : nullptr;
+    }
+    eqlib::Direct3DTexture9* GetTexture() const
+    {
+        return IsTexture() ? static_cast<eqlib::Direct3DTexture9*>(GetPointer()) : nullptr;
     }
 
     operator intptr_t() const { return reinterpret_cast<intptr_t>(GetPointer()); }
@@ -259,13 +294,18 @@ public:
 
     void* GetPointer() const
     {
-        return reinterpret_cast<void*>(value & ~0x8000000000000000);
+        return reinterpret_cast<void*>(value & ~0xC000000000000000);
     }
 
 private:
     void SetBitmap(const eqlib::CEQGBitmap* bitmap)
     {
         value = reinterpret_cast<uintptr_t>(bitmap) | 0x8000000000000000;
+    }
+
+    void SetTexture(const eqlib::Direct3DTexture9* texture)
+    {
+        value = reinterpret_cast<uintptr_t>(texture) | 0xC000000000000000;
     }
 
     void SetPointer(void* pointer)

--- a/include/mq/base/Color.h
+++ b/include/mq/base/Color.h
@@ -62,8 +62,8 @@ public:
 	struct bgr_t {};
 	static const inline bgr_t format_bgr;
 
-	struct bgra_t {};
-	static const inline bgra_t format_bgra;
+	struct abgr_t {};
+	static const inline abgr_t format_abgr;
 
 	struct argb_t {};
 	static const inline argb_t format_argb;
@@ -76,7 +76,7 @@ public:
 	{
 	}
 
-	constexpr MQColor(bgra_t, uint32_t bgracolor)
+	constexpr MQColor(abgr_t, uint32_t bgracolor)
 		: Alpha((bgracolor >> 24) & 0xff)
 		, Blue((bgracolor >> 16) & 0xff)
 		, Green((bgracolor >> 8) & 0xff)
@@ -195,6 +195,16 @@ public:
 	constexpr MQColor GetInverted() const
 	{
 		return MQColor((0xFFFFFF - (ARGB & 0xFFFFFF)) | (ARGB & 0xFF000000));
+	}
+
+	constexpr MQColor operator+(MQColor other) const
+	{
+		return MQColor(
+			static_cast<uint8_t>(std::min(std::max(Red + other.Red, 0), 255)),
+			static_cast<uint8_t>(std::min(std::max(Green + other.Green, 0), 255)),
+			static_cast<uint8_t>(std::min(std::max(Blue + other.Blue, 0), 255)),
+			static_cast<uint8_t>(std::min(std::max(Alpha + other.Alpha, 0), 255))
+		);
 	}
 
 	// Layout matches ARGBCOLOR

--- a/include/mq/imgui/Widgets.h
+++ b/include/mq/imgui/Widgets.h
@@ -21,23 +21,81 @@ namespace eqlib {
 	class CTextureAnimation;
 	struct CUITextureInfo;
 	class CUITexturePiece;
+	class CSpellGemWnd;
 }
 
 namespace mq::imgui {
 
+constexpr MQColor NoBorderColor = MQColor(0, 0, 0, 0); // No border
+constexpr MQColor DefaultBorderColor = MQColor(255, 255, 255, 127); // Light white border
+constexpr MQColor DefaultTintColor = MQColor(255, 255, 255, 255); // White/clear
+
 // Draws a CTextureAnimation. This is the preferred method for drawing a UI texture to imgui.
 // This function uses the provided size, if available. Otherwise, it uses the internally
 // specified size of the texture.
-MQLIB_OBJECT bool DrawTextureAnimation(const eqlib::CTextureAnimation* textureAnimation, const eqlib::CXSize& size = eqlib::CXSize(),
-	bool drawBorder = false);
+MQLIB_OBJECT bool DrawTextureAnimation(
+	const eqlib::CTextureAnimation* textureAnimation,
+	const eqlib::CXSize& size = eqlib::CXSize(),
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
 
-// Draws a CUITextureInfo. This is the lowest level of the UI texture hierarchy, and represents a full individual texture.
-MQLIB_OBJECT bool DrawUITexture(const eqlib::CUITextureInfo& textureInfo, const eqlib::CXRect& rect = eqlib::CXRect(0, 0, -1, -1),
-	const eqlib::CXSize& size = eqlib::CXSize(), bool drawBorder = false);
+inline bool DrawTextureAnimation(
+	const eqlib::CTextureAnimation* textureAnimation,
+	const eqlib::CXSize& size,
+	bool drawBorder)
+{
+	return DrawTextureAnimation(textureAnimation, size, DefaultTintColor, drawBorder ? DefaultBorderColor : NoBorderColor);
+}
 
-// Draws a TexturePiece. srcRect can be used to draw only a sub-section of the full texture.
-MQLIB_OBJECT bool DrawTexturePiece(const eqlib::CUITexturePiece& texturePiece, const eqlib::CXRect& srcRect, const eqlib::CXSize& imageSize, bool drawBorder = false);
-MQLIB_OBJECT bool DrawTexturePiece(const eqlib::CUITexturePiece& texturePiece, const eqlib::CXSize& imageSize, bool drawBorder = false);
+// Draws a CUITextureInfo at the current cursor location. This is the lowest level of the UI texture hierarchy, and represents a full individual texture.
+MQLIB_OBJECT bool DrawUITexture(
+	const eqlib::CUITextureInfo& textureInfo,
+	const eqlib::CXSize& size = eqlib::CXSize(),
+	const eqlib::CXRect& sourceRect = eqlib::CXRect(0, 0, -1, -1),
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
+
+inline bool DrawUITexture(
+	const eqlib::CUITextureInfo& textureInfo,
+	const eqlib::CXSize& size,
+	const eqlib::CXRect& sourceRect,
+	bool drawBorder)
+{
+	return DrawUITexture(textureInfo, size, sourceRect, DefaultTintColor, drawBorder ? DefaultBorderColor : NoBorderColor);
+}
+
+// Draws a TexturePiece. srcRect can be used to draw only a subsection of the full texture.
+MQLIB_OBJECT bool DrawTexturePiece(
+	const eqlib::CUITexturePiece& texturePiece,
+	const eqlib::CXSize& size,
+	const eqlib::CXRect& sourceRect,
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
+
+inline bool DrawTexturePiece(
+	const eqlib::CUITexturePiece& texturePiece,
+	const eqlib::CXSize& imageSize,
+	const eqlib::CXRect& sourceRect,
+	bool drawBorder)
+{
+	return DrawTexturePiece(texturePiece, imageSize, sourceRect, DefaultTintColor, drawBorder ? DefaultBorderColor : NoBorderColor);
+}
+
+// Draw a TexturePiece
+MQLIB_OBJECT bool DrawTexturePiece(
+	const eqlib::CUITexturePiece& texturePiece,
+	const eqlib::CXSize& imageSize,
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
+
+inline bool DrawTexturePiece(
+	const eqlib::CUITexturePiece& texturePiece,
+	const eqlib::CXSize& imageSize,
+	bool drawBorder)
+{
+	return DrawTexturePiece(texturePiece, imageSize, DefaultTintColor, drawBorder ? DefaultBorderColor : NoBorderColor);
+}
+
 
 //
 // Same as above drawing APIs, but allow drawing to a drawlist instead of the current window.
@@ -46,16 +104,56 @@ MQLIB_OBJECT bool DrawTexturePiece(const eqlib::CUITexturePiece& texturePiece, c
 // Adds a TextureAnimation to the specified draw list. This is the preferred method for drawing a UI texture to imgui.
 // This function uses the provided size, if available. Otherwise, it uses the internally
 // specified size of the texture.
-MQLIB_OBJECT bool AddTextureAnimation(ImDrawList* drawList, const eqlib::CTextureAnimation* textureAnimation, const eqlib::CXPoint& pos,
-	const eqlib::CXSize& size = eqlib::CXSize());
+MQLIB_OBJECT bool AddTextureAnimation(
+	ImDrawList* drawList,
+	const eqlib::CTextureAnimation* textureAnimation,
+	const eqlib::CXPoint& pos,
+	const eqlib::CXSize& size = eqlib::CXSize(),
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
 
-// Adds a CUITextureInfo to the specified draw list. This is the lowest level of the UI texture hierarchy, and represents a full individual texture.
-MQLIB_OBJECT bool AddUITexture(ImDrawList* drawList, const eqlib::CUITextureInfo& textureInfo, const eqlib::CXPoint& pos, const eqlib::CXRect& rect = eqlib::CXRect(0, 0, -1, -1),
-	const eqlib::CXSize& size = eqlib::CXSize());
+// Adds a CUITextureInfo to the specified draw list. This is thbe lowest level of the UI texture hierarchy, and represents a full individual texture.
+MQLIB_OBJECT bool AddUITexture(
+	ImDrawList* drawList,
+	const eqlib::CUITextureInfo& textureInfo,
+	const eqlib::CXPoint& pos,
+	const eqlib::CXSize& size = eqlib::CXSize(),
+	const eqlib::CXRect& sourceRect = eqlib::CXRect(0, 0, -1, -1),
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
 
-// Draws a TexturePiece. srcRect can be used to draw only a sub-section of the full texture.
-MQLIB_OBJECT bool AddTexturePiece(ImDrawList* drawList, const eqlib::CUITexturePiece& texturePiece, const eqlib::CXPoint& pos, const eqlib::CXRect& srcRect, const eqlib::CXSize& imageSize);
-MQLIB_OBJECT bool AddTexturePiece(ImDrawList* drawList, const eqlib::CUITexturePiece& texturePiece, const eqlib::CXPoint& pos, const eqlib::CXSize& imageSize);
+// Draws a TexturePiece. srcRect can be used to draw only a subsection of the full texture.
+MQLIB_OBJECT bool AddTexturePiece(
+	ImDrawList* drawList,
+	const eqlib::CUITexturePiece& texturePiece,
+	const eqlib::CXPoint& pos,
+	const eqlib::CXSize& size,
+	const eqlib::CXRect& sourceRect,
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
+
+MQLIB_OBJECT bool AddTexturePiece(
+	ImDrawList* drawList,
+	const eqlib::CUITexturePiece& texturePiece,
+	const eqlib::CXPoint& pos,
+	const eqlib::CXSize& size,
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor);
+
+
+//
+// Draw EQ UI Components with ImGui
+//
+
+// Draw a SpellGem
+MQLIB_OBJECT bool SpellGem(const char* strId, const eqlib::CSpellGemWnd* pSpellGem);
+
+// Draw a SpellGem to a draw list
+MQLIB_OBJECT void AddSpellGem(ImDrawList* drawList,
+	const eqlib::CSpellGemWnd* pSpellGem,
+	const eqlib::CXPoint& position,
+	bool hovered = false);
+
 
 //
 // Misc
@@ -72,5 +170,7 @@ MQLIB_OBJECT bool ItemLinkText(std::string_view str, mq::MQColor color, mq::MQCo
 
 MQLIB_OBJECT bool ItemLinkTextV(const char* str_id, mq::MQColor color, const char* fmt, va_list args);
 MQLIB_OBJECT bool ItemLinkText(const char* str_id, mq::MQColor color, const char* fmt, ...);
+
+
 
 } // namespace mq::imgui

--- a/include/mq/imgui/Widgets.h
+++ b/include/mq/imgui/Widgets.h
@@ -24,6 +24,19 @@ namespace eqlib {
 	class CSpellGemWnd;
 }
 
+using ImGuiSpellGemFlags = int;  // -> enum ImGuiSpellGemFlags_     // Flags: for mq::imgui::SpellGem
+
+// Flags for SpellGem()
+enum ImGuiSpellGemFlags_
+{
+	ImGuiSpellGemFlags_None = 0,
+	ImGuiSpellGemFlags_AllowSpellCast    = 1 << 0,   // Allow casting spell with left click
+	ImGuiSpellGemFlags_AllowUnmemorize   = 1 << 1,   // Allow unmemorizing spell with right click
+	ImGuiSpellGemFlags_AllowSpellDrag    = 1 << 2,   // Allow dragging spell with left click and hold
+
+	ImGuiSpellGemFlags_AllowAll          = ImGuiSpellGemFlags_AllowSpellCast | ImGuiSpellGemFlags_AllowUnmemorize | ImGuiSpellGemFlags_AllowSpellDrag,
+};
+
 namespace mq::imgui {
 
 constexpr MQColor NoBorderColor = MQColor(0, 0, 0, 0); // No border
@@ -146,7 +159,7 @@ MQLIB_OBJECT bool AddTexturePiece(
 //
 
 // Draw a SpellGem
-MQLIB_OBJECT bool SpellGem(const char* strId, const eqlib::CSpellGemWnd* pSpellGem);
+MQLIB_OBJECT bool SpellGem(const char* strId, eqlib::CSpellGemWnd* pSpellGem, ImGuiSpellGemFlags flags = ImGuiSpellGemFlags_None);
 
 // Draw a SpellGem to a draw list
 MQLIB_OBJECT void AddSpellGem(ImDrawList* drawList,

--- a/include/mq/imgui/Widgets.h
+++ b/include/mq/imgui/Widgets.h
@@ -18,6 +18,7 @@
 #include "eqlib/Common.h"
 
 namespace eqlib {
+	class CScreenPieceTemplate;
 	class CTextureAnimation;
 	struct CUITextureInfo;
 	class CUITexturePiece;
@@ -117,7 +118,7 @@ inline bool DrawTexturePiece(
 // Adds a TextureAnimation to the specified draw list. This is the preferred method for drawing a UI texture to imgui.
 // This function uses the provided size, if available. Otherwise, it uses the internally
 // specified size of the texture.
-MQLIB_OBJECT bool AddTextureAnimation(
+MQLIB_OBJECT bool DrawTextureAnimation(
 	ImDrawList* drawList,
 	const eqlib::CTextureAnimation* textureAnimation,
 	const eqlib::CXPoint& pos,
@@ -125,8 +126,29 @@ MQLIB_OBJECT bool AddTextureAnimation(
 	const MQColor& tintColor = DefaultTintColor,
 	const MQColor& borderColor = NoBorderColor);
 
+inline bool DrawTextureAnimation(
+	ImDrawList* drawList,
+	const eqlib::CTextureAnimation* textureAnimation,
+	const eqlib::CXRect& rect,
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor)
+{
+	return DrawTextureAnimation(drawList, textureAnimation, rect.TopLeft(), rect.GetSize(), tintColor, borderColor);
+}
+
+inline bool AddTextureAnimation(
+	ImDrawList* drawList,
+	const eqlib::CTextureAnimation* textureAnimation,
+	const eqlib::CXPoint& pos,
+	const eqlib::CXSize& size = eqlib::CXSize(),
+	const MQColor& tintColor = DefaultTintColor,
+	const MQColor& borderColor = NoBorderColor)
+{
+	return DrawTextureAnimation(drawList, textureAnimation, pos, size, tintColor, borderColor);
+}
+
 // Adds a CUITextureInfo to the specified draw list. This is thbe lowest level of the UI texture hierarchy, and represents a full individual texture.
-MQLIB_OBJECT bool AddUITexture(
+MQLIB_OBJECT bool DrawUITexture(
 	ImDrawList* drawList,
 	const eqlib::CUITextureInfo& textureInfo,
 	const eqlib::CXPoint& pos,
@@ -136,7 +158,7 @@ MQLIB_OBJECT bool AddUITexture(
 	const MQColor& borderColor = NoBorderColor);
 
 // Draws a TexturePiece. srcRect can be used to draw only a subsection of the full texture.
-MQLIB_OBJECT bool AddTexturePiece(
+MQLIB_OBJECT bool DrawTexturePiece(
 	ImDrawList* drawList,
 	const eqlib::CUITexturePiece& texturePiece,
 	const eqlib::CXPoint& pos,
@@ -145,7 +167,7 @@ MQLIB_OBJECT bool AddTexturePiece(
 	const MQColor& tintColor = DefaultTintColor,
 	const MQColor& borderColor = NoBorderColor);
 
-MQLIB_OBJECT bool AddTexturePiece(
+MQLIB_OBJECT bool DrawTexturePiece(
 	ImDrawList* drawList,
 	const eqlib::CUITexturePiece& texturePiece,
 	const eqlib::CXPoint& pos,
@@ -158,32 +180,42 @@ MQLIB_OBJECT bool AddTexturePiece(
 // Draw EQ UI Components with ImGui
 //
 
+MQLIB_OBJECT void DrawScreenPiece(
+	ImDrawList* drawList,
+	const eqlib::CScreenPieceTemplate* pTemplate,
+	const eqlib::CXRect& rect);
+
 // Draw a SpellGem
 MQLIB_OBJECT bool SpellGem(const char* strId, eqlib::CSpellGemWnd* pSpellGem, ImGuiSpellGemFlags flags = ImGuiSpellGemFlags_None);
 
 // Draw a SpellGem to a draw list
-MQLIB_OBJECT void AddSpellGem(ImDrawList* drawList,
+MQLIB_OBJECT void DrawSpellGem(ImDrawList* drawList,
 	const eqlib::CSpellGemWnd* pSpellGem,
 	const eqlib::CXPoint& position,
 	bool hovered = false);
 
+// Draw a SpellGem to a draw list
+//MQLIB_OBJECT void DrawSpellGem(ImDrawList* drawList, int SpellID, const CXRect& rect, bool hovered);
 
 //
 // Misc
 //
 
-MQLIB_VAR mq::MQColor DefaultLinkHoverColor;
+
+// Draw text in the style of an EQ font. Flags is a value of DrawTextFlags.
+MQLIB_OBJECT void DrawEQText(ImDrawList* drawList, int fontStyle, const char* text, const eqlib::CXRect& rect,
+	MQColor color = MQColor(255, 255, 255), uint16_t flags = 0);
 
 //
 // 
 //
+
+constexpr mq::MQColor DefaultLinkHoverColor = MQColor(0, 0, 255);
 
 // Draws a text link styled like an item link. Returns true if the link has been clicked.
 MQLIB_OBJECT bool ItemLinkText(std::string_view str, mq::MQColor color, mq::MQColor colorHovered = DefaultLinkHoverColor);
 
 MQLIB_OBJECT bool ItemLinkTextV(const char* str_id, mq::MQColor color, const char* fmt, va_list args);
 MQLIB_OBJECT bool ItemLinkText(const char* str_id, mq::MQColor color, const char* fmt, ...);
-
-
 
 } // namespace mq::imgui

--- a/src/main/ImGuiBackendDX11.cpp
+++ b/src/main/ImGuiBackendDX11.cpp
@@ -308,17 +308,26 @@ void ImGui_ImplDX11_RenderDrawData(ImDrawData* draw_data)
 				ID3D11ShaderResourceView* texture_srv = nullptr;
 				ImTextureID texID = pcmd->GetTexID();
 				
-				if (texID.IsBitmap())
+				if (texID.IsBitmap() || texID.IsTexture())
 				{
-					const eqlib::CEQGBitmap* bitmap = texID.GetBitmap();
+					eqlib::Direct3DTexture9* texture;
 
-					eqlib::Direct3DTexture9* texture = bitmap->GetD3DTexture();
+					if (texID.IsTexture())
+					{
+						texture = texID.GetTexture();
+					}
+					else
+					{
+						const eqlib::CEQGBitmap* bitmap = texID.GetBitmap();
+						texture = bitmap->GetD3DTexture();
+					}
+
 					if (texture != nullptr)
 					{
 						// Force a load of the texture if it hasn't been loaded yet.
-						if (bitmap->GetTexture() == nullptr)
+						if (texture->GetShaderResourceView() == nullptr)
 						{
-							gpD3D9Device->SetTexture(0, bitmap->GetD3DTexture());
+							gpD3D9Device->SetTexture(0, texture);
 							gpD3D9Device->SetTexture(0, nullptr);
 						}
 

--- a/src/main/ImGuiManager.cpp
+++ b/src/main/ImGuiManager.cpp
@@ -356,12 +356,17 @@ enum class DebugTab {
 	MouseInput = 0,
 	Graphics = 1,
 	Fonts = 2,
+	Cursor = 3,
 
 	None = -1,
 };
+static DebugTab s_selectedDebugTab = DebugTab::None;
 static DebugTab s_selectDebugTab = DebugTab::None;
 static bool s_overlayDebug = false;
 static bool s_enableCursorAttachment = true;
+static ImGuiWindow* s_cursorLastHoveredWindow = nullptr;  // only used for comparison. might be invalid.
+static std::string s_cursorLastHoveredWindowName;
+static bool s_showCursorAttachment = false;
 
 static mq::PlatformHotkey gToggleConsoleHotkey;
 static const char gToggleConsoleDefaultBind[] = "ctrl+`";
@@ -645,6 +650,7 @@ void UpdateImGuiDebugInfo()
 		{
 			if (ImGui::BeginTabItem("Mouse", nullptr, (s_selectDebugTab == DebugTab::MouseInput) ? ImGuiTabItemFlags_SetSelected : 0))
 			{
+				s_selectedDebugTab = DebugTab::MouseInput;
 				ImGuiIO& io = ImGui::GetIO();
 
 				// Display ImGuiIO output flags
@@ -672,13 +678,57 @@ void UpdateImGuiDebugInfo()
 
 			if (ImGui::BeginTabItem("Graphics", nullptr, (s_selectDebugTab == DebugTab::Graphics) ? ImGuiTabItemFlags_SetSelected : 0))
 			{
+				s_selectedDebugTab = DebugTab::Graphics;
+
 				engine::ImGuiRenderDebug_UpdateImGui();
 				ImGui::EndTabItem();
 			}
 
 			if (ImGui::BeginTabItem("Fonts", nullptr, (s_selectDebugTab == DebugTab::Fonts) ? ImGuiTabItemFlags_SetSelected : 0))
 			{
+				s_selectedDebugTab = DebugTab::Fonts;
+
 				FontPicker();
+				ImGui::EndTabItem();
+			}
+
+			if (ImGui::BeginTabItem("Cursor", nullptr, (s_selectDebugTab == DebugTab::Cursor) ? ImGuiTabItemFlags_SetSelected : 0))
+			{
+				s_selectedDebugTab = DebugTab::Cursor;
+
+				ImGui::TextUnformatted("Hovered Window:");
+				ImGui::SameLine();
+				if (!s_cursorLastHoveredWindowName.empty())
+				{
+					ImGui::TextColored(MQColor(255, 255, 0).ToImColor(), "%s", s_cursorLastHoveredWindowName.c_str());
+				}
+				else
+				{
+					ImGui::TextColored(MQColor(128, 128, 128).ToImColor(), "None");
+				}
+
+				ImGui::TextUnformatted("Has Cursor Attachment:");
+				ImGui::SameLine();
+				if (pCursorAttachment && pCursorAttachment->IsActive())
+				{
+					ImGui::TextColored(MQColor(0, 255, 0).ToImColor(), "Yes");
+				}
+				else
+				{
+					ImGui::TextColored(MQColor(255, 0, 0).ToImColor(), "No");
+				}
+
+				ImGui::TextUnformatted("Show Cursor Attachment:");
+				ImGui::SameLine();
+				if (s_showCursorAttachment)
+				{
+					ImGui::TextColored(MQColor(0, 255, 0).ToImColor(), "Yes");
+				}
+				else
+				{
+					ImGui::TextColored(MQColor(255, 0, 0).ToImColor(), "No");
+				}
+
 				ImGui::EndTabItem();
 			}
 
@@ -710,6 +760,13 @@ static int s_showForFrames = 0;
 
 static bool ImGuiManager_DetectCursorAttachment()
 {
+	if (!s_enableCursorAttachment || !pCursorAttachment || !pCursorAttachment->IsActive())
+	{
+		s_cursorLastHoveredWindow = nullptr;
+		s_cursorLastHoveredWindowName.clear();
+		return false;
+	}
+
 	auto& io = ImGui::GetIO();
 	auto* context = ImGui::GetCurrentContext();
 	bool show = false;
@@ -723,12 +780,12 @@ static bool ImGuiManager_DetectCursorAttachment()
 	else
 	{
 		// Check to see if the cursor would overlap a window
-		ImVec2 attachmentSize(32, 32);
+		ImVec2 attachmentSize(50, 50);
 
-		ImGuiWindow* window = ImGui::FindWindowByName("##CursorAttachment");
-		if (window)
+		ImGuiWindow* attachmentWindow = ImGui::FindWindowByName("##CursorAttachment");
+		if (attachmentWindow)
 		{
-			attachmentSize = window->Size;
+			attachmentSize = attachmentWindow->Size;
 		}
 
 		// Create rect
@@ -738,7 +795,9 @@ static bool ImGuiManager_DetectCursorAttachment()
 		{
 			ImGuiWindow* window = context->Windows[i];
 
-			if (!window->Active || window->Hidden)
+			if (!window->Active)
+				continue;
+			if (window->Hidden || window->IsFallbackWindow)
 				continue;
 			if (window->Flags & ImGuiWindowFlags_NoMouseInputs)
 				continue;
@@ -754,7 +813,7 @@ static bool ImGuiManager_DetectCursorAttachment()
 			if (window->HitTestHoleSize.x != 0)
 			{
 				ImVec2 hole_pos(window->Pos.x + (float)window->HitTestHoleOffset.x, window->Pos.y + (float)window->HitTestHoleOffset.y);
-				ImVec2 hole_size((float)window->HitTestHoleSize.x, (float)window->HitTestHoleSize.y);
+				ImVec2 hole_size(window->HitTestHoleSize.x, window->HitTestHoleSize.y);
 				if (ImRect(hole_pos, hole_pos + hole_size).Contains(io.MousePos))
 					continue;
 			}
@@ -765,14 +824,6 @@ static bool ImGuiManager_DetectCursorAttachment()
 		}
 	}
 
-	ImGui::Begin("CursorAttachment Debug");
-	if (overlappedWindow)
-	{
-		ImGui::Text("%s", overlappedWindow->Name);
-		ImGui::Text("Show: %s", show ? "true" : "false");
-	}
-	ImGui::End();
-
 	if (show)
 	{
 		s_showForFrames = 3;
@@ -782,6 +833,16 @@ static bool ImGuiManager_DetectCursorAttachment()
 		--s_showForFrames;
 	}
 
+	if (s_cursorLastHoveredWindow != overlappedWindow && s_selectedDebugTab == DebugTab::Cursor)
+	{
+		s_cursorLastHoveredWindow = overlappedWindow;
+
+		if (overlappedWindow)
+			s_cursorLastHoveredWindowName = overlappedWindow->Name;
+		else
+			s_cursorLastHoveredWindowName.clear();
+	}
+
 	gbHideCursorAttachment = s_showForFrames > 0;
 	return s_showForFrames > 0;
 }
@@ -789,8 +850,6 @@ static bool ImGuiManager_DetectCursorAttachment()
 void ImGuiManager_DrawFrame()
 {
 	MQScopedBenchmark bm1(bmUpdateImGui);
-
-	bool showCursorAttachment = ImGuiManager_DetectCursorAttachment();
 
 	DoImGuiUpdateInternal();
 
@@ -846,128 +905,128 @@ void ImGuiManager_DrawFrame()
 		UpdateImGuiDebugInfo();
 	}
 
-	ImGuiManager_DrawCursorAttachment(showCursorAttachment);
+	s_showCursorAttachment = ImGuiManager_DetectCursorAttachment();
+	if (s_showCursorAttachment)
+	{
+		ImGuiManager_DrawCursorAttachment();
+	}
 }
 
-void ImGuiManager_DrawCursorAttachment(bool show)
+void ImGuiManager_DrawCursorAttachment()
 {
 	if (!pCursorAttachment || !pCursorAttachment->IsActive())
 		return;
 
+	ImVec2 pos = ImGui::GetMousePos() + ImVec2(1, 1);
+	ImVec2 size = pCursorAttachment->GetClientRect().GetSize();
+
+	ImGui::SetNextWindowPos(pos, ImGuiCond_Always);
+	ImGui::SetNextWindowSize(size, ImGuiCond_Always);
+
+	bool show = ImGui::Begin("##CursorAttachment", nullptr,
+		ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoFocusOnAppearing
+		| ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking);
 	if (show)
 	{
-		ImVec2 pos = ImGui::GetMousePos() + ImVec2(1, 1);
-		ImVec2 size = pCursorAttachment->GetClientRect().GetSize();
+		ImGuiWindow* window = ImGui::GetCurrentWindow();
+		CXRect rect = CXRect(CXPoint(pos), CXSize(size));
 
-		ImGui::SetNextWindowPos(pos, ImGuiCond_Always);
-		ImGui::SetNextWindowSize(size, ImGuiCond_Always);
-
-		show = ImGui::Begin("##CursorAttachment", nullptr,
-			ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoFocusOnAppearing
-			| ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking);
-
-		if (show)
+		if (pCursorAttachment->pBGStaticAnim)
 		{
-			ImGuiWindow* window = ImGui::GetCurrentWindow();
-			CXRect rect = CXRect(CXPoint(pos), CXSize(size));
+			mq::imgui::DrawScreenPiece(window->DrawList, pCursorAttachment->pBGStaticAnim, rect);
+		}
 
+		if (pCursorAttachment->pOverlayStaticAnim)
+		{
+			mq::imgui::DrawScreenPiece(window->DrawList, pCursorAttachment->pOverlayStaticAnim, rect);
+		}
+
+		ECursorAttachmentType type = static_cast<ECursorAttachmentType>(pCursorAttachment->Type);
+
+		if (type == eCursorAttachment_SpellGem)
+		{
+			if (pCursorAttachment->pSpellGem && pCursorAttachment->pSpellGem->IsVisible())
+			{
+				// Draw the spell gem using the widget API because we want it to also reserve space in the window.
+				ImGui::SetCursorPos(pCursorAttachment->pSpellGem->Location.TopLeft());
+				mq::imgui::SpellGem("##SpellGem", pCursorAttachment->pSpellGem, ImGuiSpellGemFlags_None);
+			}
+		}
+
+		// Draw button text
+		if (!pCursorAttachment->ButtonText.empty())
+		{
+			CXRect textRect;
 			if (pCursorAttachment->pBGStaticAnim)
 			{
-				mq::imgui::DrawScreenPiece(window->DrawList, pCursorAttachment->pBGStaticAnim, rect);
+				textRect = pCursorAttachment->pBGStaticAnim->rect;
+				textRect += pos;
+			}
+			else
+			{
+				textRect = rect;
 			}
 
-			if (pCursorAttachment->pOverlayStaticAnim)
-			{
-				mq::imgui::DrawScreenPiece(window->DrawList, pCursorAttachment->pOverlayStaticAnim, rect);
-			}
+			mq::imgui::DrawEQText(window->DrawList, FontStyle_14, pCursorAttachment->ButtonText.c_str(),
+				textRect, MQColor(255, 255, 255), DrawText_VCenter | DrawText_HCenter);
+		}
 
-			ECursorAttachmentType type = static_cast<ECursorAttachmentType>(pCursorAttachment->Type);
+		// Draw currency/stack size
+		if (pCursorAttachment->Quantity > 0)
+		{
+			window->DrawList->PushClipRectFullScreen();
 
-			if (type == eCursorAttachment_SpellGem)
+			CCachedFont* eqFont = CCachedFont::Get(pCursorAttachment->TextFontStyle);
+			ImFont* font = ImGuiManager_GetEQImFont(pCursorAttachment->TextFontStyle);
+
+			if (font && eqFont)
 			{
-				if (pCursorAttachment->pSpellGem && pCursorAttachment->pSpellGem->IsVisible())
+				fmt::memory_buffer buf;
+				fmt::format_to(fmt::appender(buf), "{:d}", pCursorAttachment->Quantity);
+				buf.push_back(0);
+
+				if (type == eCursorAttachment_Item
+					|| type == eCursorAttachment_InvSlot
+					|| type == eCursorAttachment_ItemLink
+					|| type == eCursorAttachment_KronoSlot)
 				{
-					// Draw the spell gem using the widget API because we want it to also reserve space in the window.
-					ImGui::SetCursorPos(pCursorAttachment->pSpellGem->Location.TopLeft());
-					mq::imgui::SpellGem("##SpellGem", pCursorAttachment->pSpellGem, ImGuiSpellGemFlags_None);
-				}
-			}
+					int textWidth = static_cast<int>(font->CalcTextSizeA(font->FontSize, FLT_MAX, -1.0f, buf.data(), nullptr).x);
+					if (textWidth < 10) textWidth = 10;
 
-			// Draw button text
-			if (!pCursorAttachment->ButtonText.empty())
-			{
-				CXRect textRect;
-				if (pCursorAttachment->pBGStaticAnim)
-				{
-					textRect = pCursorAttachment->pBGStaticAnim->rect;
-					textRect += pos;
+					CXRect textRect = rect;
+					textRect.bottom -= 6;
+					textRect.right -= 6;
+					textRect.top = textRect.bottom - 10;
+					textRect.left = textRect.right - textWidth;
+
+					window->DrawList->AddRectFilled(textRect.TopLeft(), textRect.BottomRight(),
+						MQColor(64, 64, 64).ToImU32());
+
+					mq::imgui::DrawEQText(window->DrawList, pCursorAttachment->TextFontStyle, buf.data(),
+						textRect);
 				}
 				else
 				{
-					textRect = rect;
-				}
+					CXRect textRect = rect;
+					textRect.top = rect.bottom - 4;
+					textRect.bottom = textRect.top + eqFont->nHeight;
 
-				mq::imgui::DrawEQText(window->DrawList, FontStyle_14, pCursorAttachment->ButtonText.c_str(),
-					textRect, MQColor(255, 255, 255), DrawText_VCenter | DrawText_HCenter);
+					window->DrawList->AddRectFilled(textRect.TopLeft(), textRect.BottomRight(),
+						MQColor(64, 64, 64).ToImU32());
+
+					mq::imgui::DrawEQText(window->DrawList, pCursorAttachment->TextFontStyle, buf.data(),
+						textRect, MQColor(255, 255, 255), DrawText_NoWrap | DrawText_HCenter);
+				}
 			}
 
-			// Draw currency/stack size
-			if (pCursorAttachment->Quantity > 0)
-			{
-				window->DrawList->PushClipRectFullScreen();
-
-				CCachedFont* eqFont = CCachedFont::Get(pCursorAttachment->TextFontStyle);
-				ImFont* font = ImGuiManager_GetEQImFont(pCursorAttachment->TextFontStyle);
-
-				if (font && eqFont)
-				{
-					fmt::memory_buffer buf;
-					fmt::format_to(fmt::appender(buf), "{:d}", pCursorAttachment->Quantity);
-					buf.push_back(0);
-
-					if (type == eCursorAttachment_Item
-						|| type == eCursorAttachment_InvSlot
-						|| type == eCursorAttachment_ItemLink
-						|| type == eCursorAttachment_KronoSlot)
-					{
-						int textWidth = static_cast<int>(font->CalcTextSizeA(font->FontSize, FLT_MAX, -1.0f, buf.data(), nullptr).x);
-						if (textWidth < 10) textWidth = 10;
-
-						CXRect textRect = rect;
-						textRect.bottom -= 6;
-						textRect.right -= 6;
-						textRect.top = textRect.bottom - 10;
-						textRect.left = textRect.right - textWidth;
-
-						window->DrawList->AddRectFilled(textRect.TopLeft(), textRect.BottomRight(),
-							MQColor(64, 64, 64).ToImU32());
-
-						mq::imgui::DrawEQText(window->DrawList, pCursorAttachment->TextFontStyle, buf.data(),
-							textRect);
-					}
-					else
-					{
-						CXRect textRect = rect;
-						textRect.top = rect.bottom - 4;
-						textRect.bottom = textRect.top + eqFont->nHeight;
-
-						window->DrawList->AddRectFilled(textRect.TopLeft(), textRect.BottomRight(),
-							MQColor(64, 64, 64).ToImU32());
-
-						mq::imgui::DrawEQText(window->DrawList, pCursorAttachment->TextFontStyle, buf.data(),
-							textRect, MQColor(255, 255, 255), DrawText_NoWrap | DrawText_HCenter);
-					}
-				}
-
-				window->DrawList->PopClipRect();
-			}
-
-			// Ensure that this window is last in the viewport
-			ImGui::BringWindowToDisplayFront(window);
+			window->DrawList->PopClipRect();
 		}
 
-		ImGui::End();
+		// Ensure that this window is last in the viewport
+		ImGui::BringWindowToDisplayFront(window);
 	}
+
+	ImGui::End();
 }
 
 bool ImGuiManager_HandleWndProc(HWND hWnd, uint32_t msg, uintptr_t wParam, intptr_t lParam)
@@ -1204,6 +1263,7 @@ void MQOverlayCommand(SPAWNINFO* pSpawn, char* szLine)
 		GetArg(szParam, szLine, 2);
 
 		bool newOverlayDebug = s_overlayDebug;
+		s_selectDebugTab = DebugTab::None;
 
 		if (szParam[0] == 0)
 		{
@@ -1217,6 +1277,16 @@ void MQOverlayCommand(SPAWNINFO* pSpawn, char* szLine)
 		else if (ci_equals(szParam, "graphics"))
 		{
 			s_selectDebugTab = DebugTab::Graphics;
+			s_overlayDebug = true;
+		}
+		else if (ci_equals(szParam, "fonts"))
+		{
+			s_selectDebugTab = DebugTab::Fonts;
+			s_overlayDebug = true;
+		}
+		else if (ci_equals(szParam, "cursor"))
+		{
+			s_selectDebugTab = DebugTab::Cursor;
 			s_overlayDebug = true;
 		}
 

--- a/src/main/ImGuiManager.cpp
+++ b/src/main/ImGuiManager.cpp
@@ -609,6 +609,20 @@ void ImGuiManager_DrawFrame()
 	{
 		UpdateImGuiDebugInfo();
 	}
+
+	ImGuiManager_DrawCursorAttachment();
+}
+
+void ImGuiManager_DrawCursorAttachment()
+{
+	if (!pCursorAttachment || !pCursorAttachment->IsVisible())
+		return;
+
+	if (pCursorAttachment->pSpellGem && pCursorAttachment->pSpellGem->IsVisible())
+	{
+		// Draw the spell gem
+		
+	}
 }
 
 bool ImGuiManager_HandleWndProc(HWND hWnd, uint32_t msg, uintptr_t wParam, intptr_t lParam)

--- a/src/main/ImGuiManager.h
+++ b/src/main/ImGuiManager.h
@@ -23,6 +23,8 @@ void ImGuiManager_Shutdown();
 void ImGuiManager_Pulse();
 
 void ImGuiManager_DrawFrame();
+void ImGuiManager_DrawCursorAttachment();
+
 bool ImGuiManager_HandleWndProc(HWND hWnd, uint32_t msg, uintptr_t wparam, intptr_t lparam);
 
 void ImGuiManager_BuildFonts(ImFontAtlas* fontAtlas);

--- a/src/main/ImGuiManager.h
+++ b/src/main/ImGuiManager.h
@@ -23,7 +23,7 @@ void ImGuiManager_Shutdown();
 void ImGuiManager_Pulse();
 
 void ImGuiManager_DrawFrame();
-void ImGuiManager_DrawCursorAttachment(bool show);
+void ImGuiManager_DrawCursorAttachment();
 
 bool ImGuiManager_HandleWndProc(HWND hWnd, uint32_t msg, uintptr_t wparam, intptr_t lparam);
 

--- a/src/main/ImGuiManager.h
+++ b/src/main/ImGuiManager.h
@@ -23,11 +23,13 @@ void ImGuiManager_Shutdown();
 void ImGuiManager_Pulse();
 
 void ImGuiManager_DrawFrame();
-void ImGuiManager_DrawCursorAttachment();
+void ImGuiManager_DrawCursorAttachment(bool show);
 
 bool ImGuiManager_HandleWndProc(HWND hWnd, uint32_t msg, uintptr_t wparam, intptr_t lparam);
 
 void ImGuiManager_BuildFonts(ImFontAtlas* fontAtlas);
+ImFont* ImGuiManager_GetEQImFont(int fontID);
+
 
 void ImGuiManager_ReloadContext();
 void ImGuiManager_CreateContext();
@@ -45,6 +47,9 @@ extern bool gbManualResetRequired;
 
 // global imgui toggle
 extern bool gbRenderImGui;
+
+// When true, hides the cursor attachment
+extern bool gbHideCursorAttachment;
 
 
 } // namespace mq

--- a/src/main/MQ2DeveloperTools.cpp
+++ b/src/main/MQ2DeveloperTools.cpp
@@ -2040,6 +2040,14 @@ public:
 
 				ImGui::EndTabItem();
 			}
+
+			if (ImGui::BeginTabItem("Fonts"))
+			{
+				DrawFonts();
+
+				ImGui::EndTabItem();
+			}
+
 			ImGui::EndTabBar();
 		}
 	}
@@ -2059,6 +2067,92 @@ public:
 		}
 
 		ImGui::Text("Rounding Mode: %s", roundingMode);
+	}
+
+	void DrawFonts()
+	{
+		if (!pGraphicsEngine) return;
+		auto resourceMgr = pGraphicsEngine->pResourceManager;
+		if (!resourceMgr) return;
+
+		CCachedFont* pCachedFont;
+		CCachedFont* pSelectedFont = nullptr;
+		EStatus status = eStatusFailure;
+
+		// GetCachedFont may crash here if the font manager hasn't been created yet, but we're
+		// using this routine to get access to the font manager. If it throws an access violation,
+		// the application state is fine, we can just bail on this attempt.
+		__try {
+			status = resourceMgr->GetCachedFont(0, reinterpret_cast<CCachedFontInterface**>(&pCachedFont));
+		} __except (EXCEPTION_EXECUTE_HANDLER) {
+			status = eStatusFailure;
+		}
+
+		if (status != eStatusSuccess) return;
+		CFontManager* fontMgr = pCachedFont->pFontManager;
+		if (!fontMgr) return;
+
+		ImVec2 availSize = ImGui::GetContentRegionAvail();
+		if (m_rightPaneSize == 0.0f)
+			m_rightPaneSize = availSize.x - m_leftPaneSize - 1;
+
+		imgui::DrawSplitter(false, 9.0f, &m_leftPaneSize, &m_rightPaneSize, 50, 250);
+
+		// Left Pane
+		{
+			ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(4, 4));
+			ImGui::BeginChild("TreeListView", ImVec2(m_leftPaneSize, ImGui::GetContentRegionAvail().y - 1), true);
+			ImGui::PopStyleVar();
+
+			for (int fontIndex = 0; fontIndex < NumFontStyles; ++fontIndex)
+			{
+				resourceMgr->GetCachedFont(fontIndex, reinterpret_cast<CCachedFontInterface**>(&pCachedFont));
+
+				ImGui::PushID(pCachedFont);
+
+				char szLabel[64];
+				sprintf_s(szLabel, "%d: %s", fontIndex, pCachedFont->strFontName.c_str());
+
+				if (ImGui::Selectable(szLabel, m_selectedFont == fontIndex))
+					m_selectedFont = fontIndex;
+
+				if (m_selectedFont == fontIndex)
+					pSelectedFont = pCachedFont;
+
+				ImGui::PopID();
+			}
+
+			ImGui::EndChild();
+		}
+
+		ImGui::SameLine();
+
+		// Right Pane
+		{
+			ImVec2 rightPaneContentSize = ImGui::GetContentRegionAvail();
+			ImGui::BeginChild("ContentView", ImVec2(rightPaneContentSize.x, rightPaneContentSize.y - 1), true);
+
+			if (pSelectedFont)
+			{
+				ImGui::Text("Font: %s", pSelectedFont->strFontName.c_str());
+				ImGui::Text("Font ID: %d", pSelectedFont->eFontId);
+
+				if (ImGui::CollapsingHeader("Textures"))
+				{
+					int index = 0;
+					for (CD3DTexturePointerNode* ptr : pSelectedFont->arTextures)
+					{
+						ImGui::Text("%d:", index++);
+
+						ImTextureID TexID = ptr->pTexture;
+
+						ImGui::Image(TexID, ImVec2(pSelectedFont->fTextureSize, pSelectedFont->fTextureSize));
+					}
+				}
+			}
+
+			ImGui::EndChild();
+		}
 	}
 
 	void DrawBitmaps()
@@ -2286,6 +2380,8 @@ private:
 	float m_leftPaneSize = 150.0f; // initial size of left column
 	float m_rightPaneSize = 0.0f;  // size of right column. Initial value calculated from left.
 	const CEQGBitmap* m_selectedBitmap = nullptr;
+
+	int m_selectedFont = 0;
 };
 
 static EngineInspector* s_engineInspector = nullptr;

--- a/src/main/MQ2FrameLimiter.cpp
+++ b/src/main/MQ2FrameLimiter.cpp
@@ -16,6 +16,7 @@
 #include "MQ2Main.h"
 
 #include "ImGuiBackend.h"
+#include "ImGuiManager.h"
 #include "imgui/ImGuiUtils.h"
 #include "MQ2DeveloperTools.h"
 
@@ -215,6 +216,32 @@ public:
 	DETOUR_TRAMPOLINE_DEF(void, DrawWindows_Trampoline, ())
 	void DrawWindows_Detour()
 	{
+		static bool lastHide = false;
+
+		if (pCursorAttachment)
+		{
+			if (gbHideCursorAttachment)
+			{
+				CXPoint pos = pCursorAttachment->Location.TopLeft();
+
+				if (pos.x < 90000)
+				{
+					pCursorAttachment->Move(CXPoint(pos.x + 90000, pos.y + 90000));
+				}
+			}
+			else if (lastHide && !gbHideCursorAttachment)
+			{
+				if (pCursorAttachment->Location.left > 80000)
+				{
+					CXPoint pos = pCursorAttachment->Location.TopLeft();
+
+					pCursorAttachment->Move(CXPoint(pos.x - 90000, pos.y - 90000));
+				}
+			}
+
+			lastHide = gbHideCursorAttachment;
+		}
+
 		if (!IsLimiterEnabled())
 		{
 			// this is a pass through if we have the frame limiter off

--- a/src/main/MQ2WindowInspector.cpp
+++ b/src/main/MQ2WindowInspector.cpp
@@ -194,7 +194,7 @@ static void ColumnValue(const char* fmt, va_list args)
 		const char* str = va_arg(args, const char*);
 
 		if (IsEmptyValue(str))
-			ImGui::TextColored(ImColor(1.0f, 1.0f, 1.0f, .5f), str);
+			ImGui::TextColored(ImColor(1.0f, 1.0f, 1.0f, .5f), "%s", str);
 		else
 			ImGui::Text("%s", str);
 	}
@@ -231,7 +231,7 @@ static bool ColumnLinkValue(const char* str_id, MQColor color, const char* fmt, 
 
 static void ColumnNumber(const char* Label, int* number)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::PushID(Label);
 	ImGui::SetNextItemWidth(-1);
@@ -244,7 +244,7 @@ static void ColumnNumber(const char* Label, int* number)
 
 static void ColumnText(const char* Label, const char* fmt, ...)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	va_list args;
 	va_start(args, fmt);
@@ -257,7 +257,7 @@ static void ColumnText(const char* Label, const char* fmt, ...)
 
 static void ColumnTextType(const char* Label, const char* Type, const char* fmt, ...)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	va_list args;
 	va_start(args, fmt);
@@ -272,7 +272,7 @@ static void ColumnTextType(const char* Label, const char* Type, const char* fmt,
 
 static bool ColumnLinkTextType(const char* Label, const char* str_id, const char* Type, const char* fmt, ...)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	va_list args;
 	va_start(args, fmt);
@@ -290,7 +290,7 @@ static bool ColumnLinkTextType(const char* Label, const char* str_id, const char
 static bool ColumnCheckBox(const char* Label, bool* value)
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	ImGui::PushID(Label); result = ImGui::Checkbox("", value); ImGui::PopID();
 	ImGui::TableNextRow();
 	ImGui::TableNextColumn();
@@ -300,7 +300,7 @@ static bool ColumnCheckBox(const char* Label, bool* value)
 static bool ColumnCheckBox(const char* Label, bool value)
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	bool value2 = value;
 	ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.6f);
 	ImGui::PushID(Label); result = ImGui::Checkbox("", &value2); ImGui::PopID();
@@ -314,7 +314,7 @@ template <typename T>
 static bool ColummCheckBox(const char* Label, T* ptr, bool (T::* getter)(), void (T::* setter)(bool))
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	bool value = ptr->getter();
 	ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.6f);
 	ImGui::PushID(Label); result = ImGui::Checkbox("", &value); ImGui::PopID();
@@ -328,7 +328,7 @@ static bool ColummCheckBox(const char* Label, T* ptr, bool (T::* getter)(), void
 static bool ColummCheckBox(const char* Label, bool (* getter)(), void (* setter)(bool))
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	bool value = getter();
 	ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 0.6f);
 	ImGui::PushID(Label); result = ImGui::Checkbox("", &value); ImGui::PopID();
@@ -342,7 +342,7 @@ static bool ColummCheckBox(const char* Label, bool (* getter)(), void (* setter)
 static bool ColumnCheckBoxFlags(const char* Label, unsigned int* flags, unsigned int flags_value)
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	ImGui::PushID(Label); result = ImGui::CheckboxFlags("", flags, flags_value); ImGui::PopID();
 	ImGui::TableNextRow();
 	ImGui::TableNextColumn();
@@ -353,7 +353,7 @@ template <typename Rep, typename Period>
 static bool ColumnElapsedTimestamp(const char* Label, std::chrono::milliseconds ms, std::chrono::duration<Rep, Period> epoch)
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	ImGui::PushID(Label);
 	if (ms.count() > 0)
 	{
@@ -362,7 +362,7 @@ static bool ColumnElapsedTimestamp(const char* Label, std::chrono::milliseconds 
 		char szTemp[32] = { 0 };
 		fmt::format_to(szTemp, "{:%H:%M:%S}", ms);
 
-		ImGui::Text(szTemp);
+		ImGui::TextUnformatted(szTemp);
 	}
 	else
 	{
@@ -377,7 +377,7 @@ static bool ColumnElapsedTimestamp(const char* Label, std::chrono::milliseconds 
 static bool ColumnElapsedTimestamp(const char* Label, int32_t ms)
 {
 	bool result = false;
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	ImGui::PushID(Label);
 	if (ms != 0)
 	{
@@ -391,7 +391,7 @@ static bool ColumnElapsedTimestamp(const char* Label, int32_t ms)
 			strcat_s(szTemp, " ago");
 		}
 
-		ImGui::Text(szTemp);
+		ImGui::TextUnformatted(szTemp);
 	}
 	else
 	{
@@ -435,7 +435,7 @@ static bool ColumnTreeNodeType(const char* Label, const char* Type, const char* 
 
 static bool ColumnTreeNodeType2(const void* Id, const char* Label, const char* Type, const char* fmt, ...)
 {
-	bool result = ImGui::TreeNode(Id, Label); ImGui::TableNextColumn();
+	bool result = ImGui::TreeNode(Id, "%s", Label); ImGui::TableNextColumn();
 
 	va_list args;
 	va_start(args, fmt);
@@ -537,7 +537,7 @@ inline bool InputColorRef(const char* label, COLORREF& color)
 
 inline void ColumnCXStr(const char* Label, CXStr* str)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::PushID(Label);
 	//ImGui::SetNextItemWidth(22);
@@ -563,7 +563,7 @@ inline void ColumnCXStr(const char* Label, CXStr* str)
 
 inline void ColumnCXStr(const char* Label, const CXStr& str, bool expandable = true)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	if (expandable)
 	{
@@ -592,7 +592,7 @@ inline void ColumnCXStr(const char* Label, const CXStr& str, bool expandable = t
 
 inline void ColumnCXSize(const char* Label, const CXSize& size)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::Text("{ w=%d, h=%d }", size.cx, size.cy); ImGui::TableNextColumn();
 
@@ -603,7 +603,7 @@ inline void ColumnCXSize(const char* Label, const CXSize& size)
 
 inline void ColumnCXRect(const char* Label, const CXRect& rect)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::Text("{ x=%d, y=%d, w=%d, h=%d }", rect.left, rect.top, rect.GetWidth(), rect.GetHeight()); ImGui::TableNextColumn();
 
@@ -683,7 +683,7 @@ inline bool ColumnCXRect(const char* Label, CXRect* rect)
 
 inline void ColumnCXPoint(const char* Label, const CXPoint& point)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::Text("{ x=%d, y=%d }", point.x, point.y); ImGui::TableNextColumn();
 
@@ -694,7 +694,7 @@ inline void ColumnCXPoint(const char* Label, const CXPoint& point)
 
 inline void ColumnCVector3(const char* Label, const CVector3& point)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::Text("{ x=%.2f, y=%.2f, z=%.2f }", point.X, point.Y, point.Z); ImGui::TableNextColumn();
 
@@ -706,7 +706,7 @@ inline void ColumnCVector3(const char* Label, const CVector3& point)
 
 inline void ColumnColor(const char* Label, MQColor color)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	//ImGui::ColorButton(id, ImGui::ColorConvertU32ToFloat4(color),
 	//ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0));
@@ -724,7 +724,7 @@ inline void ColumnColor(const char* Label, MQColor color)
 
 inline void ColumnColor(const char* Label, const COLORREF& color)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	//ImGui::ColorButton(id, ImGui::ColorConvertU32ToFloat4(color),
 	//ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0));
@@ -742,7 +742,7 @@ inline void ColumnColor(const char* Label, const COLORREF& color)
 
 inline void ColumnColor(const char* Label, COLORREF* color)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	//ImGui::ColorButton(id, ImGui::ColorConvertU32ToFloat4(color),
 	//ColorButton(const char* desc_id, const ImVec4& col, ImGuiColorEditFlags flags = 0, ImVec2 size = ImVec2(0, 0));
@@ -763,7 +763,7 @@ inline void ColumnColor(const char* Label, COLORREF* color)
 template <typename T>
 static bool ColumnColor(const char* Label, T* ptr, COLORREF(T::* getter)() const, void (T::* setter)(COLORREF))
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	ImGui::PushID(Label);
 	ImColor colors = MQColor{ MQColor::format_argb, (ptr->*getter)()}.ToImColor();
@@ -797,7 +797,7 @@ inline bool ColumnFont(const char* Label, CTextureFont** ppFont)
 {
 	bool changed = false;
 	// Label
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	// Font ComboBox
 	if (pWndMgr)
@@ -837,7 +837,7 @@ inline bool ColumnFont(const char* Label, CTextureFont** ppFont)
 
 void ColumnTextureAnimationPreview(const char* Label, const CTextureAnimation* pAnim)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	if (!pAnim)
 		ImGui::TextColored(ImColor(1.0f, 1.0f, 1.0f, .5f), "(null)");
@@ -855,9 +855,9 @@ void ColumnTextureAnimationPreview(const char* Label, const CTextureAnimation* p
 
 bool ColumnTextureInfoPreview(const char* Label, const CUITextureInfo& textureInfo, const CXRect& rect = CXRect(0, 0, -1, -1))
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
-	bool result = imgui::DrawUITexture(textureInfo, rect, CXSize(), true);
+	bool result = imgui::DrawUITexture(textureInfo, CXSize(), rect, true);
 	ImGui::TableNextRow();
 	ImGui::TableNextColumn();
 	return result;
@@ -1373,7 +1373,7 @@ void DisplayTextObject(const char* label, CTextObjectInterface* pTextObjectInter
 
 void ColumnWindow(const char* Label, CXWnd* window)
 {
-	TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+	TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 
 	if (!window)
 		ImGui::TextColored(ImColor(1.0f, 1.0f, 1.0f, .5f), "(null)");
@@ -1461,7 +1461,7 @@ bool ColumnEQZoneIndex(const char* Label, EQZoneIndex zoneId, bool treeNode = fa
 	}
 	else
 	{
-		TreeAdvanceToLabelPos(); ImGui::Text(Label); ImGui::TableNextColumn();
+		TreeAdvanceToLabelPos(); ImGui::TextUnformatted(Label); ImGui::TableNextColumn();
 	}
 
 	EQZoneInfo* pZoneInfo = pWorldData->GetZone(zoneId);
@@ -2432,7 +2432,7 @@ public:
 
 	void DisplayCSpellGemWndProperties(CSpellGemWnd* pWnd, bool open = true)
 	{
-		DisplayCXWndProperties(pWnd, false);
+		DisplayCButtonWndProperties(static_cast<CButtonWnd*>(m_window), false);
 
 		if (BeginColorSection("CSpellGemWnd Properties", open))
 		{
@@ -2440,6 +2440,32 @@ public:
 
 			DisplayTextureAnimation("Spell icon texture", pWnd->SpellIconTexture);
 			DisplayTextureAnimation("Custom icon texture", pWnd->CustomIconTexture);
+			ColumnCheckBox("Checked", &pWnd->bChecked);
+
+			size_t numTints = lengthof(pWnd->SpellGemTintArray);
+			if (ColumnTreeNodeType("SpellGemTintArray", "MQColor[]", "%d", numTints))
+			{
+				char label[16] = { 0 };
+
+				for (size_t i = 0; i < numTints; ++i)
+				{
+					sprintf_s(label, "%zd", i);
+					ColumnColor(label, MQColor(pWnd->SpellGemTintArray[i]));
+				}
+
+				ImGui::TreePop();
+			}
+
+			// Draw the spell gem
+			TreeAdvanceToLabelPos(); ImGui::TextUnformatted("Spell Gem"); ImGui::TableNextColumn();
+			if (mq::imgui::SpellGem("##InspectorSpellGem", pWnd))
+			{
+				pWnd->ParentWndNotification(pWnd, XWM_LCLICK, nullptr);
+			}
+
+			ImGui::TableNextRow();
+			ImGui::TableNextColumn();
+
 		}
 	}
 

--- a/src/main/MQ2WindowInspector.cpp
+++ b/src/main/MQ2WindowInspector.cpp
@@ -2456,12 +2456,11 @@ public:
 				ImGui::TreePop();
 			}
 
+			pWnd->bChecked = static_cast<CButtonWnd*>(pWnd)->bChecked;
+
 			// Draw the spell gem
 			TreeAdvanceToLabelPos(); ImGui::TextUnformatted("Spell Gem"); ImGui::TableNextColumn();
-			if (mq::imgui::SpellGem("##InspectorSpellGem", pWnd))
-			{
-				pWnd->ParentWndNotification(pWnd, XWM_LCLICK, nullptr);
-			}
+			mq::imgui::SpellGem("##InspectorSpellGem", pWnd, ImGuiSpellGemFlags_AllowAll);
 
 			ImGui::TableNextRow();
 			ImGui::TableNextColumn();

--- a/src/main/MQ2WindowInspector.cpp
+++ b/src/main/MQ2WindowInspector.cpp
@@ -3804,8 +3804,8 @@ static void WindowProperty_CursorAttachment(CSidlScreenWnd* pSidlWindow, ImGuiWi
 	{
 		DisplayDynamicTemplateExpand("Background", pCursorAttachment->pBGStaticAnim, "CStaticAnimationTemplate*");
 		DisplayDynamicTemplateExpand("Overlay", pCursorAttachment->pOverlayStaticAnim, "CStaticAnimationTemplate*");
-		DisplayTextObject("Text Object", pCursorAttachment->pTextObjectInterface);
-		DisplayTextObject("Button Text Object", pCursorAttachment->pButtonTextObjectInterface);
+		DisplayTextObject("Text Object", pCursorAttachment->pTextObject);
+		DisplayTextObject("Button Text Object", pCursorAttachment->pButtonTextObject);
 		ColumnText("Text Font Style", "%d", pCursorAttachment->TextFontStyle);
 	}
 

--- a/src/main/MQImguiWidgets.cpp
+++ b/src/main/MQImguiWidgets.cpp
@@ -318,7 +318,7 @@ bool AddTextureAnimation(
 // EQ UI Draw Routines
 //
 
-bool SpellGem(const char* strId, const eqlib::CSpellGemWnd* pSpellGem)
+bool SpellGem(const char* strId, eqlib::CSpellGemWnd* pSpellGem, ImGuiSpellGemFlags flags)
 {
 	ImGuiWindow* window = ImGui::GetCurrentWindow();
 	if (window->SkipItems)
@@ -337,9 +337,27 @@ bool SpellGem(const char* strId, const eqlib::CSpellGemWnd* pSpellGem)
 	ImDrawList* drawList = window->DrawList;
 
 	bool hovered, held;
-	bool pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, 0);
+	bool pressed = ImGui::ButtonBehavior(bb, id, &hovered, &held, ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight);
 
 	AddSpellGem(drawList, pSpellGem, thePos, hovered);
+
+	if (pressed)
+	{
+		if ((flags & ImGuiSpellGemFlags_AllowSpellCast) && ImGui::IsItemHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Left))
+		{
+			pSpellGem->ParentWndNotification(pSpellGem, XWM_LCLICK, nullptr);
+
+		}
+		else if ((flags & ImGuiSpellGemFlags_AllowUnmemorize) && pSpellGem->SpellIconIndex >= 0 && ImGui::IsItemHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Right))
+		{
+			pSpellGem->ParentWndNotification(pSpellGem, XWM_RCLICK, nullptr);
+		}
+	}
+	else if ((flags & ImGuiSpellGemFlags_AllowSpellDrag) && ImGui::IsItemHovered() && ImGui::GetIO().MouseDownDuration[ImGuiMouseButton_Left] > 0.750f)
+	{
+		pSpellGem->ParentWndNotification(pSpellGem, XWM_LCLICKHOLD, nullptr);
+		pSpellGem->ParentWndNotification(pSpellGem, XWM_LBUTTONUPAFTERHELD, nullptr);
+	}
 
 	return pressed;
 }

--- a/src/plugins/lua/bindings/lua_ImGuiCustom.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiCustom.cpp
@@ -43,7 +43,12 @@ void RegisterBindings_ImGuiCustom(sol::table& ImGui)
 	ImGui.set_function("Unregister", lua_removeimgui);
 
 	ImGui.set_function("DrawTextureAnimation", sol::overload(
-		[](CTextureAnimation* anim, const ImVec2& size, std::optional<bool> drawBorder) { return mq::imgui::DrawTextureAnimation(anim, size, drawBorder.value_or(false)); },
+		[](CTextureAnimation* anim, const ImVec2& size, std::optional<int> tintColor, std::optional<int> borderColor) {
+			return mq::imgui::DrawTextureAnimation(anim, size,
+			MQColor(MQColor::format_abgr, tintColor.value_or(mq::imgui::DefaultTintColor.ToImU32())),
+			MQColor(MQColor::format_abgr, borderColor.value_or(mq::imgui::NoBorderColor.ToImU32())));
+		},
+		[](CTextureAnimation* anim, const ImVec2& size, bool drawBorder) { return mq::imgui::DrawTextureAnimation(anim, size, drawBorder); },
 		[](CTextureAnimation* anim, int x, int y, std::optional<bool> drawBorder) { return mq::imgui::DrawTextureAnimation(anim, CXSize(x, y), drawBorder.value_or(false)); },
 		[](CTextureAnimation* anim) { return mq::imgui::DrawTextureAnimation(anim); }
 	));
@@ -73,12 +78,12 @@ void RegisterBindings_ImGuiCustom(sol::table& ImGui)
 
 				pThis->AppendText(text, mq::imgui::ConsoleWidget::DEFAULT_COLOR, true);
 			},
-			[](mq::imgui::ConsoleWidget* pThis, int col, std::string_view text) { pThis->AppendText(text, MQColor(MQColor::format_bgra, col), true); },
+			[](mq::imgui::ConsoleWidget* pThis, int col, std::string_view text) { pThis->AppendText(text, MQColor(MQColor::format_abgr, col), true); },
 			[](mq::imgui::ConsoleWidget* pThis, int col, std::string_view format, sol::variadic_args va, sol::this_state s) {
 				sol::function string_format = sol::state_view(s)["string"]["format"];
 				std::string text = string_format(format, va);
 
-				pThis->AppendText(text, MQColor(MQColor::format_bgra, col), true);
+				pThis->AppendText(text, MQColor(MQColor::format_abgr, col), true);
 			},
 			[](mq::imgui::ConsoleWidget* pThis, const ImVec4& col, std::string_view text) { pThis->AppendText(text, MQColor(col), true); },
 			[](mq::imgui::ConsoleWidget* pThis, const ImVec4& col, std::string_view format, sol::variadic_args va, sol::this_state s) {
@@ -90,7 +95,7 @@ void RegisterBindings_ImGuiCustom(sol::table& ImGui)
 		),
 		"AppendTextUnformatted", sol::overload(
 			[](mq::imgui::ConsoleWidget* pThis, std::string_view text) { pThis->AppendText(text, mq::imgui::ConsoleWidget::DEFAULT_COLOR, false); },
-			[](mq::imgui::ConsoleWidget* pThis, int col, std::string_view text) { pThis->AppendText(text, MQColor(MQColor::format_bgra, col), false); },
+			[](mq::imgui::ConsoleWidget* pThis, int col, std::string_view text) { pThis->AppendText(text, MQColor(MQColor::format_abgr, col), false); },
 			[](mq::imgui::ConsoleWidget* pThis, const ImVec4& col, std::string_view text) { pThis->AppendText(text, MQColor(col), false); }
 		)
 	);

--- a/src/plugins/lua/bindings/lua_ImGuiUserTypes.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiUserTypes.cpp
@@ -304,7 +304,7 @@ void RegisterBindings_ImGuiUserTypes(sol::state_view lua)
 
 	imDrawList.set_function("AddTextureAnimation",
 		[](ImDrawList& mThis, const std::unique_ptr<eqlib::CTextureAnimation>& anim, const ImVec2& pos, std::optional<ImVec2> size) {
-			return imgui::AddTextureAnimation(&mThis, anim.get(), pos, size.has_value() ? *size : eqlib::CXSize());
+			return imgui::DrawTextureAnimation(&mThis, anim.get(), pos, size.has_value() ? *size : eqlib::CXSize());
 		});
 
 


### PR DESCRIPTION
When your mouse cursor moves over an imgui window, any item/button/spell/etc attached to the cursor will continue to appear on the cursor, like magic.