### PR TITLE
Add load all button instead of click profile parent

### DIFF
--- a/src/loader/AutoLoginImGui.cpp
+++ b/src/loader/AutoLoginImGui.cpp
@@ -2266,6 +2266,13 @@ void ShowAutoLoginMenu()
 					ImGui::TableSetupColumn("Persona", ImGuiTableColumnFlags_WidthAlwaysAutoResize);
 					ImGui::TableSetupColumn("Character Name", ImGuiTableColumnFlags_WidthStretch);
 
+					ImGui::TableNextRow(ImGuiTableRowFlags_None);
+					ImGui::TableNextColumn();
+					if (ImGui::Selectable("Load All", false, ImGuiSelectableFlags_SpanAllColumns))
+					{
+						LoadProfileGroup(group);
+					}
+
 					for (auto& profile : profiles.Updated())
 					{
 						ImGui::TableNextRow(ImGuiTableRowFlags_None);
@@ -2290,9 +2297,6 @@ void ShowAutoLoginMenu()
 
 				ImGui::EndMenu();
 			}
-
-			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
-				LoadProfileGroup(group);
 		}
 		ImGui::EndMenu();
 	}


### PR DESCRIPTION
Adds back the "Load All" button to the profile group submenu instead of clicking on the profile group name in the list of profile groups.

![image](https://github.com/macroquest/macroquest/assets/100880604/4734b8f3-93c6-4574-964a-a669254b6c93)
