### PR TITLE
Updates examples/fish.lua

### DIFF
--- a/src/plugins/lua/lua/examples/fish.lua
+++ b/src/plugins/lua/lua/examples/fish.lua
@@ -1,28 +1,28 @@
 local mq = require('mq')
-local ForceEnd = function ()
+local function ForceEnd()
     mq.exit()
 end
 
 mq.event('BrokenPole', "#*#You can't fish without a fishing pole, go buy one.#*#", ForceEnd)
 mq.event('NoBait', "#*#You can't fish without fishing bait, go buy some.#*#", ForceEnd)
 
-local KeepItem = function ()
-    while (mq.TLO.Cursor.ID() ~= 0) do
+local function KeepItem()
+    while (mq.TLO.Cursor()) do
         if (mq.TLO.Cursor.Name() == "Tattered Cloth Sandal" or mq.TLO.Cursor.Name() == "Rusty Dagger") then
-            mq.cmd.destroy()
-            mq.delay('1s')
-        else 
+            mq.cmd('/destroy')
+            mq.delay(1000)
+        else
             if (mq.TLO.Cursor.Name() ~= "Fish Scales") then
-                mq.cmd.echo('Caught '..mq.TLO.Cursor.Name())
+                printf('Caught %s', mq.TLO.Cursor.Name())
             end
-            cmd.autoinventory()
+            mq.cmd('/autoinventory')
         end
     end
 end
 
-local CheckPole = function ()
-    if (string.find(mq.TLO.Me.Inventory('mainhand').Name(), 'The Bone Rod') ~= nil) then return end
-    mq.cmd.echo('You need to put your fishing pole in your primary hand.')
+local function CheckPole()
+    if mq.TLO.Me.Inventory('mainhand').Type() == 'Fishing Pole' then return end
+    print('You need to put your fishing pole in your primary hand.')
     mq.exit()
 end
 
@@ -31,11 +31,11 @@ while true do
     mq.delay(10)
 
     KeepItem()
-    mq.cmd.doability('Fishing')
+    mq.cmd('/doability Fishing')
     mq.delay(10)
 
     KeepItem()
-    mq.cmd.doability('Forage')
+    mq.cmd('/doability Forage')
     mq.delay(10)
 
     mq.doevents()


### PR DESCRIPTION
Updates the examples/lua.fish with:

Updated functions from function expression declaration to direct declarations
Removed use of mq.cmd.echo to output to the console, and replaced its use with print and printf
Removed use of mq.cmd.xxx commands and replaced them with the generally accepted mq.cmd('/command) syntax