### PR TITLE
Added nullptr check to avoid a silent crash to desktop

### DIFF
--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1992,9 +1992,11 @@ PLUGIN_API void OnUpdateImGui()
 
 				// avoid a silent crash to desktop by ensuring selection.table is valid
 				char* selected_file = nullptr;
+
 				if (selection.table != nullptr) {
-					if (selection.table->filePathName != nullptr && selection.table->fileName != nullptr) {
+					if (selection.table->filePathName != nullptr) {
 						selected_file = selection.table->filePathName;
+					} else if (selection.table->fileName != nullptr) {
 						selected_file = selection.table->fileName;
 					}
 				}
@@ -2026,8 +2028,9 @@ PLUGIN_API void OnUpdateImGui()
 						args = std::string(user_datas);
 
 					LuaRunCommand(script_name, allocate_args(args));
+				} else {
+					WriteChatf("No file was selected or file does not exist.");
 				}
-				WriteChatf("No file was selected or file does not exist.");
 
 				IGFD_Selection_DestroyContent(&selection);
 			}

--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1989,7 +1989,13 @@ PLUGIN_API void OnUpdateImGui()
 			if (IGFD_IsOk(s_scriptLaunchDialog))
 			{
 				IGFD_Selection selection = IGFD_GetSelection(s_scriptLaunchDialog, IGFD_ResultMode_KeepInputFile);
-				char* selected_file = selection.table->filePathName;
+
+				// avoid a silent crash to desktop by ensuring selection.table is valid
+				char* selected_file = (selection.table != nullptr) ? (
+					(selection.table->filePathName != nullptr) ? selection.table->filePathName : (
+						(selection.table->fileName != nullptr) ? selection.table->fileName : nullptr
+					)
+				) : nullptr;
 
 				std::error_code ec;
 				if (selected_file != nullptr && std::filesystem::exists(selected_file, ec))
@@ -2019,6 +2025,7 @@ PLUGIN_API void OnUpdateImGui()
 
 					LuaRunCommand(script_name, allocate_args(args));
 				}
+				WriteChatf("No file was selected or file does not exist.");
 
 				IGFD_Selection_DestroyContent(&selection);
 			}

--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1991,11 +1991,13 @@ PLUGIN_API void OnUpdateImGui()
 				IGFD_Selection selection = IGFD_GetSelection(s_scriptLaunchDialog, IGFD_ResultMode_KeepInputFile);
 
 				// avoid a silent crash to desktop by ensuring selection.table is valid
-				char* selected_file = (selection.table != nullptr) ? (
-					(selection.table->filePathName != nullptr) ? selection.table->filePathName : (
-						(selection.table->fileName != nullptr) ? selection.table->fileName : nullptr
-					)
-				) : nullptr;
+				char* selected_file = nullptr;
+				if (selection.table != nullptr) {
+					if (selection.table->filePathName != nullptr && selection.table->fileName != nullptr) {
+						selected_file = selection.table->filePathName;
+						selected_file = selection.table->fileName;
+					}
+				}
 
 				std::error_code ec;
 				if (selected_file != nullptr && std::filesystem::exists(selected_file, ec))


### PR DESCRIPTION
Fix applied to avoid a silent crash to desktop by ensuring selection.table is valid.

The crash would occur when pressing Lua Task Manager -> Launch Script -> OK button without selecting an existing file.