### PR TITLE
Fix DoCommandf passing incorrect parameter to DoCommand

### DIFF
--- a/src/main/MQCommandAPI.cpp
+++ b/src/main/MQCommandAPI.cpp
@@ -1095,7 +1095,7 @@ void DoCommandf(const char* szFormat, ...)
 
 	vsprintf_s(szOutput, len, szFormat, vaList);
 
-	pCommandAPI->DoCommand(szFormat, false);
+	pCommandAPI->DoCommand(szOutput, false);
 }
 
 fEQCommand FindEQCommand(std::string_view command)


### PR DESCRIPTION
I noticed an issue with the /aa command referenced in issue #875 and tracked it down to the DoCommandF incorrectly passing the format string instead of the output string to the DoCommand function.
