### PR TITLE
added /mqlog2 command Usage: /mqlog2 <filename> <log text>

### DIFF
--- a/src/main/MQ2Commands.h
+++ b/src/main/MQ2Commands.h
@@ -39,6 +39,7 @@ MQLIB_API void Continue                            (PlayerClient* pChar, const c
 MQLIB_API void ListMacros                          (PlayerClient* pChar, const char* szLine);
 MQLIB_API void SquelchCommand                      (PlayerClient* pChar, const char* szLine);
 MQLIB_API void MacroLog                            (PlayerClient* pChar, const char* szLine);
+MQLIB_API void MacroLog2							(PlayerClient* pChar, const char* szLine);
 MQLIB_API void MacroBeep                           (PlayerClient* pChar, const char* szLine);
 MQLIB_API void Echo                                (PlayerClient* pChar, const char* szLine);
 MQLIB_API void EchoClean                           (PlayerClient* pChar, const char* szLine);

--- a/src/main/MQCommandAPI.cpp
+++ b/src/main/MQCommandAPI.cpp
@@ -209,6 +209,7 @@ MQCommandAPI::MQCommandAPI()
 		{ "/mqlistmodules",     ListModulesCommand,         false, false },
 		{ "/mqlistprocesses",   ListProcessesCommand,       false, false },
 		{ "/mqlog",             MacroLog,                   true,  false },
+		{ "/mqlog2",            MacroLog2,                  true,  false },
 		{ "/mqpause",           MacroPause,                 true,  false },
 		{ "/mqtarget",          Target,                     true,  true  },
 		{ "/msgbox",            MQMsgBox,                   true,  false },


### PR DESCRIPTION
This way you can debug to a specified file and not have to hunt through MacroQuest.log for what you need.