### PR TITLE
Overlay writeout clarification

### DIFF
--- a/src/main/ImGuiManager.cpp
+++ b/src/main/ImGuiManager.cpp
@@ -1304,7 +1304,7 @@ void MQOverlayCommand(SPAWNINFO* pSpawn, char* szLine)
 		}
 		else
 		{
-			WriteChatf("Overlay is already running");
+			WriteChatf("Overlay is not suspended; Can not resume.");
 		}
 	}
 	else if (ci_equals(szArg, "stop"))


### PR DESCRIPTION
- clarified when an mqoverlay is not suspended, that it can not be resumed. If you had stopped mqoverlay and then did a resume, it would say it was already running.
