### PR TITLE
Feat - add CustomCharacterINI to type member

### DIFF
--- a/src/plugins/autologin/MQ2AutoLogin.cpp
+++ b/src/plugins/autologin/MQ2AutoLogin.cpp
@@ -53,7 +53,8 @@ public:
 		Profile,
 		Account,
 		Class,
-		Level
+		Level,
+		CustomCharacterIni,
 	};
 
 	LoginProfileType() : MQ2Type("LoginProfile")
@@ -65,6 +66,7 @@ public:
 		ScopedTypeMember(LoginProfileMembers, Account);
 		ScopedTypeMember(LoginProfileMembers, Class);
 		ScopedTypeMember(LoginProfileMembers, Level);
+		ScopedTypeMember(LoginProfileMembers, CustomCharacterIni);
 	}
 
 	virtual bool GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest) override
@@ -121,6 +123,11 @@ public:
 		case LoginProfileMembers::Level:
 			Dest.Int = record->characterLevel;
 			Dest.Type = mq::datatypes::pIntType;
+			return true;
+		case LoginProfileMembers::CustomCharacterIni:
+			strcpy_s(DataTypeTemp, record->customClientIni ? record->customClientIni->c_str() : "No Custom INI");
+			Dest.Ptr = &DataTypeTemp[0];
+			Dest.Type = mq::datatypes::pStringType;
 			return true;
 		}
 

--- a/src/plugins/autologin/MQ2AutoLogin.cpp
+++ b/src/plugins/autologin/MQ2AutoLogin.cpp
@@ -125,7 +125,7 @@ public:
 			Dest.Type = mq::datatypes::pIntType;
 			return true;
 		case LoginProfileMembers::CustomCharacterIni:
-			strcpy_s(DataTypeTemp, record->customClientIni ? record->customClientIni->c_str() : "No Custom INI");
+			strcpy_s(DataTypeTemp, record->customClientIni ? record->customClientIni->c_str() : "");
 			Dest.Ptr = &DataTypeTemp[0];
 			Dest.Type = mq::datatypes::pStringType;
 			return true;
@@ -227,7 +227,7 @@ static void Post(const proto::login::MessageId& messageId, const std::string& da
 void NotifyCharacterLoad(const std::shared_ptr<ProfileRecord>& ptr)
 {
 	auto& record = *ptr;
-	
+
 	// Fill in the profile first.
 	if (!record.profileName.empty())
 	{
@@ -1492,9 +1492,9 @@ static void ShowAutoLoginOverlay(bool* p_open)
 
 		default: break;
 		}
-	
+
 		ImGui::Spacing();
-	
+
 		if (ImGui::CollapsingHeader("Settings"))
 		{
 			ImGui::Checkbox("Kick Active Character", &Login::m_settings.KickActiveCharacter);


### PR DESCRIPTION
- adds CustomCharacterINI to typemember
- - ex: mq.TLO.AutoLogin.Profile.CustomCharacterIni() and ${AutoLogin.Profile.CustomCharacterINI}
