### PR TITLE
Lua spawn functions multistate

### DIFF
--- a/src/plugins/lua/LuaThread.cpp
+++ b/src/plugins/lua/LuaThread.cpp
@@ -658,7 +658,6 @@ void LuaThread::AssociateTopLevelObject(const MQTopLevelObject* tlo)
 
 //============================================================================
 
-// TODO: Remove the debugging statements
 void LuaThread::InitializeSpawnTable()
 {
 	if (m_spawnTable == sol::nil)

--- a/src/plugins/lua/LuaThread.cpp
+++ b/src/plugins/lua/LuaThread.cpp
@@ -694,16 +694,6 @@ void LuaThread::RemoveSpawn(eqlib::PlayerClient* spawn)
 	}
 }
 
-sol::table LuaThread::GetSpawns(sol::state_view L)
-{
-	sol::table source = m_globalState["__spawns"];
-	sol::table target = L.create_table();
-	for (auto [key, val] : source)
-		target.set(sol::make_object(L, key), sol::make_object(L, val));
-
-	return target;
-}
-
 void LuaThread::InitializeGroundItemTable()
 {
 	if (m_globalState["__groundItems"] == sol::nil)
@@ -738,11 +728,6 @@ void LuaThread::RemoveGroundItem(eqlib::EQGroundItem* item)
 		WriteChatf("Removing groundItem %s", item->Name);
 		m_globalState["__groundItems"][item->DropID] = sol::nil;
 	}
-}
-
-sol::table LuaThread::GetGroundItems(sol::state_view L)
-{
-	return m_globalState["__groundItems"];
 }
 
 } // namespace mq::lua

--- a/src/plugins/lua/LuaThread.cpp
+++ b/src/plugins/lua/LuaThread.cpp
@@ -671,7 +671,6 @@ void LuaThread::InitializeSpawnTable()
 
 			while (spawn != nullptr)
 			{
-				WriteChatf("Adding spawn %s", spawn->Name);
 				spawn_table[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
 				spawn = spawn->GetNext();
 			}
@@ -681,19 +680,19 @@ void LuaThread::InitializeSpawnTable()
 
 void LuaThread::AddSpawn(eqlib::PlayerClient* spawn)
 {
-	if (m_globalState["__spawns"] != sol::nil)
+	sol::table spawns = m_globalState["__spawns"];
+	if (spawns != sol::nil)
 	{
-		WriteChatf("Adding spawn %s", spawn->Name);
-		m_globalState["__spawns"][spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
+		spawns[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
 	}
 }
 
 void LuaThread::RemoveSpawn(eqlib::PlayerClient* spawn)
 {
-	if (m_globalState["__spawns"] != sol::nil)
+	sol::table spawns = m_globalState["__spawns"];
+	if (spawns != sol::nil)
 	{
-		WriteChatf("Removing spawn %s", spawn->Name);
-		m_globalState["__spawns"][spawn->SpawnID] = sol::nil;
+		spawns[spawn->SpawnID] = sol::nil;
 	}
 }
 
@@ -708,7 +707,6 @@ void LuaThread::InitializeGroundItemTable()
 			auto item = pItemList->Top;
 			while (item != nullptr)
 			{
-				WriteChatf("Adding groundItem %s", item->Name);
 				item_table[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
 				item = item->pNext;
 			}
@@ -718,19 +716,19 @@ void LuaThread::InitializeGroundItemTable()
 
 void LuaThread::AddGroundItem(eqlib::EQGroundItem* item)
 {
-	if (m_globalState["__groundItems"] != sol::nil)
+	sol::table items = m_globalState["__groundItems"];
+	if (items != sol::nil)
 	{
-		WriteChatf("Adding groundItem %s", item->Name);
-		m_globalState["__groundItems"][item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
+		items[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
 	}
 }
 
 void LuaThread::RemoveGroundItem(eqlib::EQGroundItem* item)
 {
-	if (m_globalState["__groundItems"] != sol::nil)
+	sol::table items = m_globalState["__groundItems"];
+	if (items != sol::nil)
 	{
-		WriteChatf("Removing groundItem %s", item->Name);
-		m_globalState["__groundItems"][item->DropID] = sol::nil;
+		items[item->DropID] = sol::nil;
 	}
 }
 

--- a/src/plugins/lua/LuaThread.cpp
+++ b/src/plugins/lua/LuaThread.cpp
@@ -661,9 +661,9 @@ void LuaThread::AssociateTopLevelObject(const MQTopLevelObject* tlo)
 // TODO: Remove the debugging statements
 void LuaThread::InitializeSpawnTable()
 {
-	if (m_globalState["__spawns"] == sol::nil)
+	if (m_spawnTable == sol::nil)
 	{
-		sol::table spawn_table = m_globalState.create_named_table("__spawns");
+		m_spawnTable = m_globalState.create_named_table("__spawns");
 
 		if (pSpawnManager != nullptr)
 		{
@@ -671,7 +671,7 @@ void LuaThread::InitializeSpawnTable()
 
 			while (spawn != nullptr)
 			{
-				spawn_table[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
+				m_spawnTable[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
 				spawn = spawn->GetNext();
 			}
 		}
@@ -680,34 +680,32 @@ void LuaThread::InitializeSpawnTable()
 
 void LuaThread::AddSpawn(eqlib::PlayerClient* spawn)
 {
-	sol::table spawns = m_globalState["__spawns"];
-	if (spawns != sol::nil)
+	if (m_coroutine->coroutine.status() == sol::call_status::yielded && m_spawnTable != sol::nil)
 	{
-		spawns[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
+		m_spawnTable[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
 	}
 }
 
 void LuaThread::RemoveSpawn(eqlib::PlayerClient* spawn)
 {
-	sol::table spawns = m_globalState["__spawns"];
-	if (spawns != sol::nil)
+	if (m_coroutine->coroutine.status() == sol::call_status::yielded && m_spawnTable != sol::nil)
 	{
-		spawns[spawn->SpawnID] = sol::nil;
+		m_spawnTable[spawn->SpawnID] = sol::nil;
 	}
 }
 
 void LuaThread::InitializeGroundItemTable()
 {
-	if (m_globalState["__groundItems"] == sol::nil)
+	if (m_groundItemTable == sol::nil)
 	{
-		sol::table item_table = m_globalState.create_named_table("__groundItems");
+		m_groundItemTable = m_globalState.create_named_table("__groundItems");
 
 		if (pItemList != nullptr)
 		{
 			auto item = pItemList->Top;
 			while (item != nullptr)
 			{
-				item_table[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
+				m_groundItemTable[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
 				item = item->pNext;
 			}
 		}
@@ -716,19 +714,17 @@ void LuaThread::InitializeGroundItemTable()
 
 void LuaThread::AddGroundItem(eqlib::EQGroundItem* item)
 {
-	sol::table items = m_globalState["__groundItems"];
-	if (items != sol::nil)
+	if (m_coroutine->coroutine.status() == sol::call_status::yielded && m_groundItemTable != sol::nil)
 	{
-		items[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
+		m_groundItemTable[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
 	}
 }
 
 void LuaThread::RemoveGroundItem(eqlib::EQGroundItem* item)
 {
-	sol::table items = m_globalState["__groundItems"];
-	if (items != sol::nil)
+	if (m_coroutine->coroutine.status() == sol::call_status::yielded && m_groundItemTable != sol::nil)
 	{
-		items[item->DropID] = sol::nil;
+		m_groundItemTable[item->DropID] = sol::nil;
 	}
 }
 

--- a/src/plugins/lua/LuaThread.cpp
+++ b/src/plugins/lua/LuaThread.cpp
@@ -658,18 +658,21 @@ void LuaThread::AssociateTopLevelObject(const MQTopLevelObject* tlo)
 
 //============================================================================
 
+// TODO: Remove the debugging statements
 void LuaThread::InitializeSpawnTable()
 {
 	if (m_globalState["__spawns"] == sol::nil)
 	{
-		m_globalState.create_named_table("__spawns");
+		sol::table spawn_table = m_globalState.create_named_table("__spawns");
 
 		if (pSpawnManager != nullptr)
 		{
 			auto spawn = pSpawnManager->FirstSpawn;
+
 			while (spawn != nullptr)
 			{
-				AddSpawn(spawn);
+				WriteChatf("Adding spawn %s", spawn->Name);
+				spawn_table[spawn->SpawnID] = bindings::lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
 				spawn = spawn->GetNext();
 			}
 		}
@@ -698,14 +701,15 @@ void LuaThread::InitializeGroundItemTable()
 {
 	if (m_globalState["__groundItems"] == sol::nil)
 	{
-		m_globalState.create_named_table("__groundItems");
+		sol::table item_table = m_globalState.create_named_table("__groundItems");
 
 		if (pItemList != nullptr)
 		{
 			auto item = pItemList->Top;
 			while (item != nullptr)
 			{
-				AddGroundItem(item);
+				WriteChatf("Adding groundItem %s", item->Name);
+				item_table[item->DropID] = bindings::lua_MQTypeVar(datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(item)));
 				item = item->pNext;
 			}
 		}

--- a/src/plugins/lua/LuaThread.h
+++ b/src/plugins/lua/LuaThread.h
@@ -26,6 +26,11 @@
 #include <chrono>
 #include <stack>
 
+namespace eqlib {
+	class PlayerClient;
+	class EQGroundItem;
+}
+
 namespace mq {
 	struct MQPlugin;
 }
@@ -189,6 +194,16 @@ public:
 	void AddNamedDependency(const std::string& name) {
 		m_namedDependencies.insert(name);
 	}
+
+	void InitializeSpawnTable();
+	void AddSpawn(eqlib::PlayerClient* spawn);
+	void RemoveSpawn(eqlib::PlayerClient* spawn);
+	sol::table GetSpawns(sol::state_view L);
+
+	void InitializeGroundItemTable();
+	void AddGroundItem(eqlib::EQGroundItem* item);
+	void RemoveGroundItem(eqlib::EQGroundItem* item);
+	sol::table GetGroundItems(sol::state_view L);
 
 private:
 	RunResult RunOnce();

--- a/src/plugins/lua/LuaThread.h
+++ b/src/plugins/lua/LuaThread.h
@@ -246,6 +246,10 @@ private:
 
 	// datatypes
 	ci_unordered::set<std::string> m_registeredTLOs;
+
+	// memoized table references
+	sol::table m_spawnTable = sol::nil;
+	sol::table m_groundItemTable = sol::nil;
 };
 
 //============================================================================

--- a/src/plugins/lua/LuaThread.h
+++ b/src/plugins/lua/LuaThread.h
@@ -198,12 +198,10 @@ public:
 	void InitializeSpawnTable();
 	void AddSpawn(eqlib::PlayerClient* spawn);
 	void RemoveSpawn(eqlib::PlayerClient* spawn);
-	sol::table GetSpawns(sol::state_view L);
 
 	void InitializeGroundItemTable();
 	void AddGroundItem(eqlib::EQGroundItem* item);
 	void RemoveGroundItem(eqlib::EQGroundItem* item);
-	sol::table GetGroundItems(sol::state_view L);
 
 private:
 	RunResult RunOnce();

--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1760,6 +1760,7 @@ PLUGIN_API void OnPulse()
 
 PLUGIN_API void OnAddSpawn(PlayerClient* spawn)
 {
+	using namespace mq::lua;
 	for (const auto& thread : s_running)
 		thread->AddSpawn(spawn);
 
@@ -1769,6 +1770,7 @@ PLUGIN_API void OnAddSpawn(PlayerClient* spawn)
 
 PLUGIN_API void OnRemoveSpawn(PlayerClient* spawn)
 {
+	using namespace mq::lua;
 	for (const auto& thread : s_running)
 		thread->RemoveSpawn(spawn);
 
@@ -1778,6 +1780,7 @@ PLUGIN_API void OnRemoveSpawn(PlayerClient* spawn)
 
 PLUGIN_API void OnAddGroundItem(EQGroundItem* item)
 {
+	using namespace mq::lua;
 	for (const auto& thread : s_running)
 		thread->AddGroundItem(item);
 
@@ -1787,6 +1790,7 @@ PLUGIN_API void OnAddGroundItem(EQGroundItem* item)
 
 PLUGIN_API void OnRemoveGroundItem(EQGroundItem* item)
 {
+	using namespace mq::lua;
 	for (const auto& thread : s_running)
 		thread->RemoveGroundItem(item);
 

--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1758,6 +1758,23 @@ PLUGIN_API void OnPulse()
 	}
 }
 
+// TODO: simply loop through threads and call these
+PLUGIN_API void OnAddSpawn(PlayerClient* spawn)
+{
+}
+
+PLUGIN_API void OnRemoveSpawn(PlayerClient* spawn)
+{
+}
+
+PLUGIN_API void OnAddGroundItem(EQGroundItem* item)
+{
+}
+
+PLUGIN_API void OnRemoveGroundItem(EQGroundItem* item)
+{
+}
+
 PLUGIN_API void OnUpdateImGui()
 {
 	using namespace mq::lua;

--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1758,21 +1758,40 @@ PLUGIN_API void OnPulse()
 	}
 }
 
-// TODO: simply loop through threads and call these
 PLUGIN_API void OnAddSpawn(PlayerClient* spawn)
 {
+	for (const auto& thread : s_running)
+		thread->AddSpawn(spawn);
+
+	for (const auto& thread : s_pending)
+		thread->AddSpawn(spawn);
 }
 
 PLUGIN_API void OnRemoveSpawn(PlayerClient* spawn)
 {
+	for (const auto& thread : s_running)
+		thread->RemoveSpawn(spawn);
+
+	for (const auto& thread : s_pending)
+		thread->RemoveSpawn(spawn);
 }
 
 PLUGIN_API void OnAddGroundItem(EQGroundItem* item)
 {
+	for (const auto& thread : s_running)
+		thread->AddGroundItem(item);
+
+	for (const auto& thread : s_pending)
+		thread->AddGroundItem(item);
 }
 
 PLUGIN_API void OnRemoveGroundItem(EQGroundItem* item)
 {
+	for (const auto& thread : s_running)
+		thread->RemoveGroundItem(item);
+
+	for (const auto& thread : s_pending)
+		thread->RemoveGroundItem(item);
 }
 
 PLUGIN_API void OnUpdateImGui()

--- a/src/plugins/lua/bindings/lua_EQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_EQBindings.cpp
@@ -263,27 +263,44 @@ void RegisterBindings_EQ(LuaThread* thread, sol::table& mq)
 	mq.set_function("initializeGroundItemTable", &lua_initializeGroundItemTable);
 
 	mq.set_function("getAllSpawns", sol::state_view(mq.lua_state()).script(R"(
-		function()
+		return function()
 			if not __spawns then require('mq').initializeSpawnTable() end
 			local spawns = {}
-			for _, spawn in ipairs(__spawns) do table.insert(spawns, spawn) end
+			for _, spawn in pairs(__spawns) do table.insert(spawns, spawn) end
 			return spawns
 		end
 	)"));
 
 	mq.set_function("getFilteredSpawns", sol::state_view(mq.lua_state()).script(R"(
-		function(predicate)
+		return function(predicate)
 			if not __spawns then require('mq').initializeSpawnTable() end
 			local spawns = {}
-			for _, spawn in ipairs(__spawns) do
+			for _, spawn in pairs(__spawns) do
 				if predicate(spawn) then table.insert(spawns, spawn) end
 			end
 			return spawns
 		end
 	)"));
 
-	mq.set_function("getAllGroundItems", sol::state_view(mq.lua_state()).script("function() return __groundItems end"));
-	mq.set_function("getFilteredGroundItems", &lua_getFilteredGroundItems);
+	mq.set_function("getAllGroundItems", sol::state_view(mq.lua_state()).script(R"(
+		return function()
+			if not __groundItems then require('mq').initializeGroundItemTable() end
+			local items = {}
+			for _, item in pairs(__groundItems) do table.insert(items, item) end
+			return items
+		end
+	)");
+
+	mq.set_function("getFilteredGroundItems", sol::state_view(mq.lua_state()).script(R"(
+		return function(predicate)
+			if not __groundItems then require('mq').initializeGroundItemTable() end
+			local items = {}
+			for _, item in pairs(__groundItems) do
+				if predicate(item) then table.insert(items, item) end
+			end
+			return items
+		end
+	)");
 }
 
 } // namespace mq::lua::bindings

--- a/src/plugins/lua/bindings/lua_EQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_EQBindings.cpp
@@ -262,16 +262,17 @@ void RegisterBindings_EQ(LuaThread* thread, sol::table& mq)
 	mq.set_function("initializeSpawnTable", &lua_initializeSpawnTable);
 	mq.set_function("initializeGroundItemTable", &lua_initializeGroundItemTable);
 
-	mq.set_function("getAllSpawns", sol::state_view(mq.lua_state()).script(R"(
+	sol::function getAllSpawns = thread->GetState().script(R"(
 		return function()
 			if not __spawns then require('mq').initializeSpawnTable() end
 			local spawns = {}
 			for _, spawn in pairs(__spawns) do table.insert(spawns, spawn) end
 			return spawns
 		end
-	)"));
+	)");
+	mq.set("getAllSpawns", getAllSpawns);
 
-	mq.set_function("getFilteredSpawns", sol::state_view(mq.lua_state()).script(R"(
+	sol::function getFilteredSpawns = thread->GetState().script(R"(
 		return function(predicate)
 			if not __spawns then require('mq').initializeSpawnTable() end
 			local spawns = {}
@@ -280,9 +281,10 @@ void RegisterBindings_EQ(LuaThread* thread, sol::table& mq)
 			end
 			return spawns
 		end
-	)"));
+	)");
+	mq.set_function("getFilteredSpawns", getFilteredSpawns);
 
-	mq.set_function("getAllGroundItems", sol::state_view(mq.lua_state()).script(R"(
+	sol::function getAllGroundItems = thread->GetState().script(R"(
 		return function()
 			if not __groundItems then require('mq').initializeGroundItemTable() end
 			local items = {}
@@ -290,8 +292,9 @@ void RegisterBindings_EQ(LuaThread* thread, sol::table& mq)
 			return items
 		end
 	)");
+	mq.set_function("getAllGroundItems", getAllGroundItems);
 
-	mq.set_function("getFilteredGroundItems", sol::state_view(mq.lua_state()).script(R"(
+	sol::function getFilteredGroundItems = thread->GetState().script(R"(
 		return function(predicate)
 			if not __groundItems then require('mq').initializeGroundItemTable() end
 			local items = {}
@@ -301,6 +304,7 @@ void RegisterBindings_EQ(LuaThread* thread, sol::table& mq)
 			return items
 		end
 	)");
+	mq.set_function("getFilteredGroundItems", getFilteredGroundItems);
 }
 
 } // namespace mq::lua::bindings

--- a/src/plugins/lua/bindings/lua_EQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_EQBindings.cpp
@@ -42,86 +42,18 @@ static std::unique_ptr<CTextureAnimation> FindTextureAnimation(std::string_view 
 
 #pragma region MQ Data Bindings
 
-static sol::table lua_getAllSpawns(sol::this_state L)
+static void lua_initializeSpawnTable(sol::this_state L)
 {
-	auto table = sol::state_view(L).create_table();
-
-	if (pSpawnManager)
-	{
-		auto spawn = pSpawnManager->FirstSpawn;
-		while (spawn != nullptr)
-		{
-			auto lua_spawn = lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
-			table.add(std::move(lua_spawn));
-
-			spawn = spawn->GetNext();
-		}
-	}
-
-	return table;
+	std::shared_ptr<LuaThread> thread = LuaThread::get_from(L);
+	if (thread)
+		thread->InitializeSpawnTable();
 }
 
-static sol::table lua_getFilteredSpawns(sol::this_state L, std::optional<sol::unsafe_function> predicate)
+static void lua_initializeGroundItemTable(sol::this_state L)
 {
-	auto table = sol::state_view(L).create_table();
-
-	if (pSpawnManager && predicate)
-	{
-		auto spawn = pSpawnManager->FirstSpawn;
-		const auto& predicate_value = predicate.value();
-		while (spawn != nullptr)
-		{
-			auto lua_spawn = lua_MQTypeVar(datatypes::pSpawnType->MakeTypeVar(spawn));
-			if (predicate_value(lua_spawn))
-				table.add(std::move(lua_spawn));
-
-			spawn = spawn->GetNext();
-		}
-	}
-
-	return table;
-}
-
-static sol::table lua_getAllGroundItems(sol::this_state L)
-{
-	auto table = sol::state_view(L).create_table();
-
-	if (pItemList)
-	{
-		auto pGroundItem = pItemList->Top;
-		while (pGroundItem != nullptr)
-		{
-			auto groundTypeVar = datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(pGroundItem));
-			auto lua_ground = lua_MQTypeVar(groundTypeVar);
-			table.add(std::move(lua_ground));
-
-			pGroundItem = pGroundItem->pNext;
-		}
-	}
-
-	return table;
-}
-
-static sol::table lua_getFilteredGroundItems(sol::this_state L, std::optional<sol::unsafe_function> predicate)
-{
-	auto table = sol::state_view(L).create_table();
-
-	if (pItemList && predicate)
-	{
-		auto pGroundItem = pItemList->Top;
-		const auto& predicate_value = predicate.value();
-		while (pGroundItem != nullptr)
-		{
-			auto groundTypeVar = datatypes::MQ2GroundType::MakeTypeVar(MQGroundSpawn(pGroundItem));
-			auto lua_ground = lua_MQTypeVar(groundTypeVar);
-			if (predicate_value(lua_ground))
-				table.add(std::move(lua_ground));
-
-			pGroundItem = pGroundItem->pNext;
-		}
-	}
-
-	return table;
+	std::shared_ptr<LuaThread> thread = LuaThread::get_from(L);
+	if (thread)
+		thread->InitializeGroundItemTable();
 }
 
 #pragma endregion
@@ -327,9 +259,30 @@ void RegisterBindings_EQ(LuaThread* thread, sol::table& mq)
 
 	//----------------------------------------------------------------------------
 	// Direct Data Bindings
-	mq.set_function("getAllSpawns", &lua_getAllSpawns);
-	mq.set_function("getFilteredSpawns", &lua_getFilteredSpawns);
-	mq.set_function("getAllGroundItems", &lua_getAllGroundItems);
+	mq.set_function("initializeSpawnTable", &lua_initializeSpawnTable);
+	mq.set_function("initializeGroundItemTable", &lua_initializeGroundItemTable);
+
+	mq.set_function("getAllSpawns", sol::state_view(mq.lua_state()).script(R"(
+		function()
+			if not __spawns then require('mq').initializeSpawnTable() end
+			local spawns = {}
+			for _, spawn in ipairs(__spawns) do table.insert(spawns, spawn) end
+			return spawns
+		end
+	)"));
+
+	mq.set_function("getFilteredSpawns", sol::state_view(mq.lua_state()).script(R"(
+		function(predicate)
+			if not __spawns then require('mq').initializeSpawnTable() end
+			local spawns = {}
+			for _, spawn in ipairs(__spawns) do
+				if predicate(spawn) then table.insert(spawns, spawn) end
+			end
+			return spawns
+		end
+	)"));
+
+	mq.set_function("getAllGroundItems", sol::state_view(mq.lua_state()).script("function() return __groundItems end"));
 	mq.set_function("getFilteredGroundItems", &lua_getFilteredGroundItems);
 }
 


### PR DESCRIPTION
Create lua spawn and ground item tables in every thread's state by lazily constructing it and updating it if the script ever uses it.