### PR TITLE
Expose the console FontSize to lua

### DIFF
--- a/include/mq/imgui/ConsoleWidget.h
+++ b/include/mq/imgui/ConsoleWidget.h
@@ -42,11 +42,11 @@ public:
 	virtual void AppendText(std::string_view text, MQColor defaultColor = DEFAULT_COLOR,
 		bool appendNewLine = false) = 0;
 
+	virtual int GetFontSize() const = 0;
+	virtual void SetFontSize(int fontSize) = 0;
+
 	virtual bool IsCursorAtEnd() const = 0;
 	virtual void ScrollToBottom() = 0;
-
-	virtual int GetConsoleFontSize() const = 0;
-	virtual void SetConsoleFontSize(int fontSize) = 0;
 
 	virtual bool GetAutoScroll() const = 0;
 	virtual void SetAutoScroll(bool autoScroll) = 0;

--- a/include/mq/imgui/ConsoleWidget.h
+++ b/include/mq/imgui/ConsoleWidget.h
@@ -45,6 +45,9 @@ public:
 	virtual bool IsCursorAtEnd() const = 0;
 	virtual void ScrollToBottom() = 0;
 
+	virtual int GetConsoleFontSize() const = 0;
+	virtual void SetConsoleFontSize(int fontSize) = 0;
+
 	virtual bool GetAutoScroll() const = 0;
 	virtual void SetAutoScroll(bool autoScroll) = 0;
 

--- a/src/main/MQ2ImGuiConsole.cpp
+++ b/src/main/MQ2ImGuiConsole.cpp
@@ -68,6 +68,7 @@ static const int s_userColorCommandLink = USERCOLOR_DIALOG_LINK;
 static const int s_userColorFactionLink = USERCOLOR_FACTION_LINK;
 #endif
 
+static int s_consoleFontSize = 13;
 static bool s_dockspaceVisible = true;
 static bool s_consoleVisible = false;
 static bool s_consoleVisibleOnStartup = false;
@@ -629,7 +630,7 @@ struct ImGuiZepConsole : public mq::imgui::ConsoleWidget, public mq::imgui::ImGu
 			Zep::SyntaxProvider{ "Console", Zep::tSyntaxFactory([this](Zep::ZepBuffer* pBuffer) {
 				return std::make_shared<ZepConsoleSyntax>(*pBuffer, m_theme, m_window);
 			})
-			});
+		});
 
 		m_buffer = GetEditor().InitWithText("Console", "");
 		m_buffer->SetTheme(m_theme);
@@ -857,8 +858,6 @@ struct ImGuiZepConsole : public mq::imgui::ConsoleWidget, public mq::imgui::ImGu
 
 	void Render(const ImVec2& displaySize = ImVec2()) override
 	{
-		SetFont(Zep::ZepTextType::Text, mq::imgui::ConsoleFont, m_fontSize);
-
 		if (m_deferredCursorToEnd)
 		{
 			m_deferredCursorToEnd = false;
@@ -1795,16 +1794,14 @@ static void ConsoleSettings()
 
 		ImGui::NewLine();
 
-		int newConsoleFontSize = gImGuiConsole->m_zepEditor->GetConsoleFontSize();
-		if (ImGui::SliderInt("Console Font Size", &newConsoleFontSize, 10, 30))
+		if (ImGui::SliderInt("Main Console Font Size", &s_consoleFontSize, 10, 30))
 		{
-			gImGuiConsole->m_zepEditor->SetConsoleFontSize(newConsoleFontSize);
-			s_consoleFontSize = newConsoleFontSize;
+			gImGuiConsole->m_zepEditor->SetConsoleFontSize(s_consoleFontSize);
 			WritePrivateProfileInt("Console", "ConsoleFontSize", s_consoleFontSize, internal_paths::MQini);
 		}
 
 		ImGui::SameLine();
-		mq::imgui::HelpMarker("Adjust the font size of the console. Changes will take effect immediately and will be saved for future sessions.");
+		mq::imgui::HelpMarker("Adjust the font size of the Main Console. Changes will take effect immediately and will be saved for future sessions.");
 
 		ImGui::NewLine();
 	}
@@ -1815,6 +1812,13 @@ static void ConsoleSettings()
 		s_consolePersistentCommandHistory = false;
 		WritePrivateProfileBool("MacroQuest", "ShowMacroQuestConsole", s_consoleVisibleOnStartup, mq::internal_paths::MQini);
 		WritePrivateProfileBool("Console", "PersistentCommandHistory", s_consolePersistentCommandHistory, mq::internal_paths::MQini);
+
+		s_consoleFontSize = 13;
+		WritePrivateProfileInt("Console", "ConsoleFontSize", s_consoleFontSize, internal_paths::MQini);
+		if (gImGuiConsole != nullptr)
+		{
+			gImGuiConsole->m_zepEditor->SetFont(Zep::ZepTextType::Text, mq::imgui::ConsoleFont, s_consoleFontSize);
+		}
 	}
 }
 
@@ -1823,15 +1827,18 @@ void InitializeImGuiConsole()
 	s_consoleVisibleOnStartup = GetPrivateProfileBool("MacroQuest", "ShowMacroQuestConsole", false, mq::internal_paths::MQini);
 	s_consoleVisible = s_consoleVisibleOnStartup;
 	s_consolePersistentCommandHistory = GetPrivateProfileBool("Console", "PersistentCommandHistory", false, mq::internal_paths::MQini);
+	s_consoleFontSize = GetPrivateProfileInt("Console", "ConsoleFontSize", s_consoleFontSize, internal_paths::MQini);
 	if (gbWriteAllConfig)
 	{
 		WritePrivateProfileBool("MacroQuest", "ShowMacroQuestConsole", s_consoleVisibleOnStartup, mq::internal_paths::MQini);
 		WritePrivateProfileBool("Console", "PersistentCommandHistory", s_consolePersistentCommandHistory, mq::internal_paths::MQini);
+		WritePrivateProfileInt("Console", "ConsoleFontSize", s_consoleFontSize, internal_paths::MQini);
 	}
 
 	AddSettingsPanel("Console", ConsoleSettings);
 
 	gImGuiConsole = new ImGuiConsole();
+	gImGuiConsole->m_zepEditor->SetFont(Zep::ZepTextType::Text, mq::imgui::ConsoleFont, s_consoleFontSize);
 	AddCommand("/mqconsole", MQConsoleCommand);
 }
 

--- a/src/plugins/lua/bindings/lua_ImGuiCustom.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiCustom.cpp
@@ -68,6 +68,7 @@ void RegisterBindings_ImGuiCustom(sol::table& ImGui)
 		"ScrollToBottom"             , &mq::imgui::ConsoleWidget::ScrollToBottom,
 		"autoScroll"                 , sol::property(&mq::imgui::ConsoleWidget::GetAutoScroll, &mq::imgui::ConsoleWidget::SetAutoScroll),
 		"maxBufferLines"             , sol::property(&mq::imgui::ConsoleWidget::GetMaxBufferLines, &mq::imgui::ConsoleWidget::SetMaxBufferLines),
+		"consoleFontSize"			 , sol::property(&mq::imgui::ConsoleWidget::GetConsoleFontSize, &mq::imgui::ConsoleWidget::SetConsoleFontSize),
 		"opacity"                    , sol::property(&mq::imgui::ConsoleWidget::GetOpacity, &mq::imgui::ConsoleWidget::SetOpacity),
 
 		"AppendText",                sol::overload(

--- a/src/plugins/lua/bindings/lua_ImGuiCustom.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiCustom.cpp
@@ -68,7 +68,7 @@ void RegisterBindings_ImGuiCustom(sol::table& ImGui)
 		"ScrollToBottom"             , &mq::imgui::ConsoleWidget::ScrollToBottom,
 		"autoScroll"                 , sol::property(&mq::imgui::ConsoleWidget::GetAutoScroll, &mq::imgui::ConsoleWidget::SetAutoScroll),
 		"maxBufferLines"             , sol::property(&mq::imgui::ConsoleWidget::GetMaxBufferLines, &mq::imgui::ConsoleWidget::SetMaxBufferLines),
-		"consoleFontSize"			 , sol::property(&mq::imgui::ConsoleWidget::GetConsoleFontSize, &mq::imgui::ConsoleWidget::SetConsoleFontSize),
+		"fontSize"					 , sol::property(&mq::imgui::ConsoleWidget::GetFontSize, &mq::imgui::ConsoleWidget::SetFontSize),
 		"opacity"                    , sol::property(&mq::imgui::ConsoleWidget::GetOpacity, &mq::imgui::ConsoleWidget::SetOpacity),
 
 		"AppendText",                sol::overload(

--- a/src/plugins/lua/lua/examples/console.lua
+++ b/src/plugins/lua/lua/examples/console.lua
@@ -10,6 +10,17 @@ local localEcho = false
 local resetPosition = false
 local commandBuffer = ''
 local setFocus = false
+local fontSize = 13
+
+local fontSizes = {}
+for i = 10, 30 do
+    if i % 2 == 0 then
+        table.insert(fontSizes, i)
+        if i == 12 then
+            table.insert(fontSizes, 13) -- this is the default font size so keep it in the list
+        end
+    end
+end
 
 function MakeColorGradient(freq1, freq2, freq3, phase1, phase2, phase3, center, width, length)
     local text = ''
@@ -35,6 +46,7 @@ end
 local GUI = function()
     if console == nil then
         console = imgui.ConsoleWidget.new("##Console")
+        console.fontSize = fontSize
     end
 
     local flags = ImGuiWindowFlags.MenuBar
@@ -70,7 +82,6 @@ local GUI = function()
             end
 
             if imgui.BeginMenu('Extras') then
-
                 if imgui.MenuItem('Color Test 1') then
                     console:AppendText("\ayYELLOW    \a-yDARK YELLOW");
                     console:AppendText("\aoORANGE    \a-oDARK ORANGE");
@@ -90,12 +101,28 @@ local GUI = function()
 
                 imgui.EndMenu()
             end
-
+            if ImGui.BeginMenu('Font Size##') then
+                ImGui.SetNextItemWidth(100)
+                if ImGui.BeginCombo("##FontSize", tostring(fontSize)) then
+                    for k, data in pairs(fontSizes) do
+                        local isSelected = data == fontSize
+                        if ImGui.Selectable(tostring(data), isSelected) then
+                            if fontSize ~= data then
+                                fontSize = data
+                                console.fontSize = data
+                            end
+                        end
+                    end
+                    ImGui.EndCombo()
+                end
+                ImGui.EndMenu()
+            end
             imgui.EndMenu()
         end
         imgui.EndMenuBar()
     end
     -- End of menu bar
+
 
     local footerHeight = imgui.GetStyle().ItemSpacing.y + imgui.GetFrameHeightWithSpacing()
 
@@ -119,9 +146,9 @@ local GUI = function()
 
     local textFlags = bit32.bor(0,
         ImGuiInputTextFlags.EnterReturnsTrue
-        -- not implemented yet
-        -- ImGuiInputTextFlags.CallbackCompletion,
-        -- ImGuiInputTextFlags.CallbackHistory
+    -- not implemented yet
+    -- ImGuiInputTextFlags.CallbackCompletion,
+    -- ImGuiInputTextFlags.CallbackHistory
     )
 
     imgui.SetCursorPosX(imgui.GetCursorPosX() + 6)
@@ -155,7 +182,7 @@ end
 
 function StringTrim(s)
     return s:gsub("^%s*(.-)%s*$", "%1")
- end
+end
 
 function ExecCommand(text)
     if localEcho then
@@ -164,7 +191,6 @@ function ExecCommand(text)
 
     -- todo: implement history
     if string.len(text) > 0 then
-
         text = StringTrim(text)
         if text == 'clear' then
             console:Clear()


### PR DESCRIPTION
Allows you to change the font size per console either on create or by modifying 

`console.consoleFontSize = #`

Added slider to the mqsettings window for the main console font size, this saves between sessions.

https://github.com/user-attachments/assets/fc95de88-cdb4-4055-a9bd-5e557ccfe2e1

