### PR TITLE
Added the ability to use "=" with /cast command.

### DIFF
--- a/src/main/MQCommands.cpp
+++ b/src/main/MQCommands.cpp
@@ -2959,7 +2959,7 @@ void Cast(PlayerClient* pChar, const char* szLine)
 	for (int Index = 0; Index < NUM_SPELL_GEMS; Index++)
 	{
 		EQ_Spell* pSpell = GetSpellByID(GetMemorizedSpell(Index));
-		if (pSpell && ci_starts_with(pSpell->Name, szArg1))
+		if (pSpell && MaybeExactCompare(pSpell->Name, szArg1))
 		{
 			if (pSpell->TargetType == TT_SPLASH)
 			{


### PR DESCRIPTION
i.e.: /cast =Bane

This will make sure that you do not cast Bane of Nife instead of Bane.