### PR TITLE
new profile default eqpath and missing dmg bonus types

### DIFF
--- a/src/loader/LoaderAutoLoginImGui.cpp
+++ b/src/loader/LoaderAutoLoginImGui.cpp
@@ -966,7 +966,7 @@ void EditBehavior(ProfileInfo& profileInfo, const char* name, const Action& ok_a
 				{
 					profileInfo.characterName = profileInfo.Character.Character;
 					profileInfo.serverName = profileInfo.Character.Server;
-					login::db::ReadAccount(profileInfo);
+					login::db::ReadAccount(profileInfo, true);
 				}
 			});
 

--- a/src/login/Login.cpp
+++ b/src/login/Login.cpp
@@ -1013,7 +1013,7 @@ void login::db::CreateAccount(const ProfileRecord& profile)
 		});
 }
 
-std::optional<std::string> login::db::ReadAccount(ProfileRecord& profile)
+std::optional<std::string> login::db::ReadAccount(ProfileRecord& profile, bool skipEqPath)
 {
 	return WithDb::Query<std::optional<std::string>>(SQLITE_OPEN_READONLY,
 		R"(
@@ -1022,7 +1022,7 @@ std::optional<std::string> login::db::ReadAccount(ProfileRecord& profile)
 				JOIN characters ON account_id = accounts.id
 				JOIN server_types ON server_type = type
 				WHERE server = LOWER(?) AND character = LOWER(?))",
-		[&profile](sqlite3_stmt* stmt, sqlite3* db) -> std::optional<std::string>
+		[&profile, skipEqPath](sqlite3_stmt* stmt, sqlite3* db) -> std::optional<std::string>
 		{
 			BindText(stmt, 1, profile.serverName);
 			BindText(stmt, 2, profile.characterName);
@@ -1031,7 +1031,10 @@ std::optional<std::string> login::db::ReadAccount(ProfileRecord& profile)
 			{
 				profile.accountName = ReadText(stmt, 0);
 				profile.serverType = ReadText(stmt, 2);
-				profile.eqPath = ReadText(stmt, 3);
+				if (!skipEqPath)
+				{
+					profile.eqPath = ReadText(stmt, 3);
+				}
 
 				std::string pass(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1)), sqlite3_column_bytes(stmt, 1));
 				if (const auto master_pass = GetMasterPass())

--- a/src/login/Login.h
+++ b/src/login/Login.h
@@ -319,7 +319,7 @@ void DeleteProfileGroup(std::string_view name);
 Results<std::pair<std::string, std::string>> ListAccounts();
 login::db::Results<ProfileRecord> ListAccountMatches(std::string_view search);
 void CreateAccount(const ProfileRecord& profile);
-std::optional<std::string> ReadAccount(ProfileRecord& profile);
+std::optional<std::string> ReadAccount(ProfileRecord& profile, bool skipEqPath = false);
 std::optional<std::string> ReadPassword(std::string_view account, std::string_view server_type, std::optional<std::string_view> password_override = {});
 void UpdateAccount(std::string_view account, std::string_view server_type, const ProfileRecord& record);
 void DeleteAccount(std::string_view account, std::string_view server_type);

--- a/src/main/MQ2Globals.cpp
+++ b/src/main/MQ2Globals.cpp
@@ -556,7 +556,9 @@ const char* szDmgBonusType[] = {
 	"Fire",
 	"Cold",
 	"Poison",
-	"Disease"
+	"Disease",
+	"Chromatic",
+	"Prismatic"
 };
 
 const char* szBodyType[] = {


### PR DESCRIPTION
Fix https://github.com/macroquest/macroquest/issues/953 by adding chromatic and prismatic damage types as defined here https://github.com/EQEmu/EQEmu/blob/9b3f9f356db1ed29ca8a098cad3682d041b0c5fd/zone/mob.cpp#L7759
Not sure if this should be something emu specific, but doesn't seem like any harm in them being in the list for live too?

And adjust behavior when adding a new profile to a profile group, to leave the eqPath as default instead of reading the current point in time eqPath from the account of the selected character. It looks like this behavior changed at some point after some refactoring where add profile switched from calling ReadProfileGroup to ReadAccount, so it would have used to get the eqpath of the group, which probably would have been default/null typically? Maybe it'd be better to switch back to that instead of just not using the path resolved from the account. There was a long overly complicated discussion about this on rg here https://discord.com/channels/228710469857181697/398938025511485440/1449416361456435374