### PR TITLE
Expose ImGuiWindowClass to Lua

### DIFF
--- a/src/plugins/lua/bindings/lua_ImGuiEnums.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiEnums.cpp
@@ -65,6 +65,27 @@ void RegisterBindings_ImGuiEnums(sol::state_view lua)
 		"AlwaysUseWindowPadding"       , ImGuiWindowFlags_AlwaysUseWindowPadding  // Obsolete
 	);
 
+	// Viewport Flags
+	lua.new_enum("ImGuiViewportFlags",
+		"None"                         , ImGuiViewportFlags_None,
+		"IsPlatformWindow"             , ImGuiViewportFlags_IsPlatformWindow,
+		"IsPlatformMonitor"            , ImGuiViewportFlags_IsPlatformMonitor,
+		"OwnedByApp"                   , ImGuiViewportFlags_OwnedByApp,
+		"NoDecoration"                 , ImGuiViewportFlags_NoDecoration,
+		"NoTaskBarIcon"                , ImGuiViewportFlags_NoTaskBarIcon,
+		"NoFocusOnAppearing"           , ImGuiViewportFlags_NoFocusOnAppearing,
+		"NoFocusOnClick"               , ImGuiViewportFlags_NoFocusOnClick,
+		"NoInputs"                     , ImGuiViewportFlags_NoInputs,
+		"NoRendererClear"              , ImGuiViewportFlags_NoRendererClear,
+		"NoAutoMerge"                  , ImGuiViewportFlags_NoAutoMerge,
+		"TopMost"                      , ImGuiViewportFlags_TopMost,
+		"CanHostOtherWindows"          , ImGuiViewportFlags_CanHostOtherWindows,
+
+		// Output status flags (read-only from platform)
+		"IsMinimized"                  , ImGuiViewportFlags_IsMinimized,
+		"IsFocused"                    , ImGuiViewportFlags_IsFocused
+	);
+
 	// Child Window Flags
 	lua.new_enum("ImGuiChildFlags",
 		"None"                         , ImGuiChildFlags_None,

--- a/src/plugins/lua/bindings/lua_ImGuiUserTypes.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiUserTypes.cpp
@@ -398,6 +398,21 @@ void RegisterBindings_ImGuiUserTypes(sol::state_view lua)
 		"TexHeight"                    , sol::readonly(&ImFontAtlas::TexHeight)
 	);
 
+	// ImGuiWindowClass
+	lua.new_usertype<ImGuiWindowClass>(
+		"ImGuiWindowClass"             , sol::call_constructor
+		                               , sol::constructors<ImGuiWindowClass()>(),
+		"ClassId"                      , &ImGuiWindowClass::ClassId,
+		"ParentViewportId"             , &ImGuiWindowClass::ParentViewportId,
+		"FocusRouteParentWindowId"     , &ImGuiWindowClass::FocusRouteParentWindowId,
+		"ViewportFlagsOverrideSet"     , &ImGuiWindowClass::ViewportFlagsOverrideSet,
+		"ViewportFlagsOverrideClear"   , &ImGuiWindowClass::ViewportFlagsOverrideClear,
+		"TabItemFlagsOverrideSet"      , &ImGuiWindowClass::TabItemFlagsOverrideSet,
+		"DockNodeFlagsOverrideSet"     , &ImGuiWindowClass::DockNodeFlagsOverrideSet,
+		"DockingAlwaysTabBar"          , &ImGuiWindowClass::DockingAlwaysTabBar,
+		"DockingAllowUnclassed"        , &ImGuiWindowClass::DockingAllowUnclassed
+	);
+
 
 	// ImGuiViewport
 	lua.new_usertype<ImGuiViewport>(

--- a/src/plugins/lua/lua/examples/external_viewport.lua
+++ b/src/plugins/lua/lua/examples/external_viewport.lua
@@ -1,0 +1,81 @@
+local mq = require('mq')
+local imgui = require('ImGui')
+
+local openGUI = true
+local shouldDrawGUI = true
+local showGUI = true
+local window_class = nil
+local topMost = true
+local attachToGameWindow = false
+local terminate = false
+
+local function GUI()
+    if not showGUI then
+        return
+    end
+    if window_class == nil then
+        window_class = ImGuiWindowClass()
+    end
+    if attachToGameWindow then
+        local mainViewport = imgui.GetMainViewport()
+        window_class.ParentViewportId = mainViewport and mainViewport.ID or 0
+        topMost = false
+    else
+        window_class.ParentViewportId = 0
+    end
+    local viewport_flags = 0
+    if not attachToGameWindow then
+        viewport_flags = ImGuiViewportFlags.NoAutoMerge
+        if topMost then
+            viewport_flags = bit32.bor(viewport_flags, ImGuiViewportFlags.TopMost)
+        end
+    end
+    window_class.ViewportFlagsOverrideSet = viewport_flags
+    window_class.ViewportFlagsOverrideClear = ImGuiViewportFlags.NoTaskBarIcon
+
+    imgui.SetNextWindowClass(window_class)
+    local window_flags = attachToGameWindow and 0 or ImGuiWindowFlags.NoDocking
+    openGUI, shouldDrawGUI = imgui.Begin('Detached Game State', openGUI, window_flags)
+    if not openGUI then
+        showGUI = false
+        terminate = true
+        imgui.End()
+        return
+    end
+    if not shouldDrawGUI then
+        imgui.End()
+        return
+    end
+
+    local gameState = mq.TLO.EverQuest.GameState() or -1
+    local zone = mq.TLO.Zone.ShortName() or 'Unknown'
+    local me = mq.TLO.Me
+    local meName = me.Name() or 'None'
+    local meHP = me.PctHPs() or 0
+    local meMana = me.PctMana() or 0
+    local meEnd = me.PctEndurance() or 0
+    local meX = me.X() or 0
+    local meY = me.Y() or 0
+    local meZ = me.Z() or 0
+
+    imgui.Text('GameState: ' .. tostring(gameState))
+    imgui.Text('Zone: ' .. tostring(zone))
+    imgui.Separator()
+    imgui.Text('Me: ' .. tostring(meName))
+    imgui.Text('HP: ' .. tostring(meHP) .. '%  Mana: ' .. tostring(meMana) .. '%  End: ' .. tostring(meEnd) .. '%')
+    imgui.Text('Pos: ' .. tostring(meX) .. ', ' .. tostring(meY) .. ', ' .. tostring(meZ))
+    attachToGameWindow = imgui.Checkbox('Attach to Game Window', attachToGameWindow)
+    imgui.BeginDisabled(attachToGameWindow)
+    topMost = imgui.Checkbox('TopMost', topMost)
+    imgui.EndDisabled()
+
+    imgui.End()
+end
+
+mq.imgui.init('DetachedGameState', GUI)
+mq.bind('/extwin', function() showGUI = not showGUI end)
+mq.bind('/extend', function() terminate = true end)
+
+while not terminate do
+    mq.delay(100)
+end


### PR DESCRIPTION
This pull request adds support for ImGui viewport and window class features to the Lua bindings, and provides a new Lua example demonstrating how to create a detached, optionally top-most ImGui window that can be attached to the game window or float externally. The main changes include exposing new ImGui enums and user types to Lua, and providing a practical usage example.

**Lua Bindings:**

* Added the `ImGuiViewportFlags` enum to the Lua bindings, making it possible to control viewport-specific window behavior from Lua scripts.
* Exposed the `ImGuiWindowClass` user type to Lua, including its properties such as `ClassId`, `ParentViewportId`, and viewport/tab/dock override flags, enabling advanced window management from Lua.

**Example and Usage:**

* Added a new Lua example script `external_viewport.lua` that demonstrates creating a detached ImGui window, optionally attaching it to the main game window, and toggling its "top-most" status. 