### PR TITLE
Fix INI read/write. Fix Autobank for EMU

### DIFF
--- a/src/plugins/autobank/MQ2AutoBank.cpp
+++ b/src/plugins/autobank/MQ2AutoBank.cpp
@@ -450,7 +450,6 @@ PLUGIN_API void InitializePlugin()
 	EzDetour(CBankWnd__WndNotification,
 		&AutoBank::BankWnd_Hook::WndNotification_Detour,
 		&AutoBank::BankWnd_Hook::WndNotification_Trampoline);
-	sprintf_s(INIFileName, MAX_PATH, "%s/AutoBank.ini", gPathConfig);
 }
 
 PLUGIN_API void ShutdownPlugin()


### PR DESCRIPTION
RoF2 does not have access to the /autobank command. 
INI was trying to write to a path and was not assigned a file name. 