### PR TITLE
MaybeExactCompare to utilize quotes

### DIFF
--- a/src/main/MQ2Inlines.h
+++ b/src/main/MQ2Inlines.h
@@ -580,6 +580,11 @@ inline bool MaybeExactCompare(std::string_view haystack, std::string_view needle
 		needle = needle.substr(1);
 		exact = true;
 	}
+	else if (needle.size() >= 2 && needle.front() == '"' && needle.back() == '"')
+	{
+		needle = needle.substr(1, needle.size() - 2);
+		exact = true;
+	}
 
 	return ci_equals(haystack, needle, exact);
 }


### PR DESCRIPTION
- this would allow a "check this in quotes" to work the same way that =this item does
