### PR TITLE
lua imgui: Fix BeginPopupModal and add mq.candelay()

### DIFF
--- a/src/plugins/lua/bindings/lua_ImGuiCore.cpp
+++ b/src/plugins/lua/bindings/lua_ImGuiCore.cpp
@@ -696,7 +696,7 @@ sol::table RegisterBindings_ImGui(sol::state_view state)
 	#pragma region Popups, Modals
 	ImGui.set_function("BeginPopup", [](const char* str_id, std::optional<int> flags) { return ImGui::BeginPopup(str_id, flags.value_or(0)); });
 	ImGui.set_function("BeginPopupModal", sol::overload(
-		[](const char* name, std::optional<bool> open, std::optional<bool> flags)
+		[](const char* name, std::optional<bool> open, std::optional<int> flags)
 		{
 			bool open_ = open.value_or(true);
 			bool show = ImGui::BeginPopupModal(name, open.has_value() ? &open_ : nullptr, flags.value_or(0));

--- a/src/plugins/lua/bindings/lua_MQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_MQBindings.cpp
@@ -112,6 +112,15 @@ static void lua_delay(sol::object delayObj, std::optional<sol::object> condition
 	}
 }
 
+static bool lua_canDelay(sol::this_state s)
+{
+	if (std::shared_ptr<LuaThread> thread_ptr = LuaThread::get_from(s))
+	{
+		return thread_ptr->GetAllowYield();
+	}
+	return false;
+}
+
 // also exposed as os.exit
 void lua_exit(sol::this_state s)
 {
@@ -530,6 +539,7 @@ void RegisterBindings_MQ(LuaThread* thread, sol::table& mq)
 
 	// thread bindings
 	mq.set_function("delay",                     &lua_delay);
+	mq.set_function("candelay",                  &lua_canDelay);
 	mq.set_function("exit",                      &lua_exit);
 
 	// event bindings

--- a/src/plugins/lua/bindings/lua_MQBindings.cpp
+++ b/src/plugins/lua/bindings/lua_MQBindings.cpp
@@ -539,7 +539,7 @@ void RegisterBindings_MQ(LuaThread* thread, sol::table& mq)
 
 	// thread bindings
 	mq.set_function("delay",                     &lua_delay);
-	mq.set_function("candelay",                  &lua_canDelay);
+	mq.set_function("canDelay",                  &lua_canDelay);
 	mq.set_function("exit",                      &lua_exit);
 
 	// event bindings

--- a/src/plugins/lua/lua/mq/ImguiHelper.lua
+++ b/src/plugins/lua/lua/mq/ImguiHelper.lua
@@ -8,7 +8,7 @@ ImguiHelper.Popup = {
             if not buttons or #buttons == 0 then
                 return 0
             end
-            if not mq.candelay() then
+            if not mq.canDelay() then
                 print("ImguiHelper.Popup.Modal cannot block in the current context (yielding is disabled, typically during require). Ensure the caller is not loading as a module.", 2)
                 mq.exit()
             end

--- a/src/plugins/lua/lua/mq/ImguiHelper.lua
+++ b/src/plugins/lua/lua/mq/ImguiHelper.lua
@@ -8,33 +8,35 @@ ImguiHelper.Popup = {
             if not buttons or #buttons == 0 then
                 return 0
             end
+            if not mq.candelay() then
+                print("ImguiHelper.Popup.Modal cannot block in the current context (yielding is disabled, typically during require). Ensure the caller is not loading as a module.", 2)
+                mq.exit()
+            end
             local last_return = 0
             local openGUI = true
-            local shouldDrawGUI = true
 
             local function DisplayModalGUI()
                 if not openGUI then return end
-                local flags = bit32.bor(ImGuiWindowFlags.NoDecoration, ImGuiWindowFlags.NoInputs, ImGuiWindowFlags.NoNav, ImGuiWindowFlags.NoDocking)
-                ImGui.SetNextWindowBgAlpha(0)
-                ImGui.SetNextWindowSize(0, 0)
-                openGUI, shouldDrawGUI = ImGui.Begin('##' .. title, openGUI, flags)
-                if shouldDrawGUI then
-                    ImGui.OpenPopup(title)
-                    if ImGui.BeginPopupModal(title) then
-                        ImGui.Text(text)
-                        ImGui.Separator()
-                        for order, button in ipairs(buttons) do
-                            if ImGui.Button(button) then
-                                openGUI = false
-                                last_return = order
-                                ImGui.CloseCurrentPopup()
-                            end
-                            ImGui.SameLine()
+                ImGui.OpenPopup(title)
+                local vp = ImGui.GetMainViewport()
+                ImGui.SetNextWindowPos(vp:GetCenter(), ImGuiCond.Appearing, ImVec2(0.5, 0.5))
+                local wrapW = math.min(ImGui.GetFontSize() * 40, vp.WorkSize.x * 0.6)
+                local popupFlags = bit32.bor(ImGuiWindowFlags.AlwaysAutoResize, ImGuiWindowFlags.NoResize, ImGuiWindowFlags.NoSavedSettings)
+                if ImGui.BeginPopupModal(title, nil, popupFlags) then
+                    ImGui.PushTextWrapPos(ImGui.GetCursorPosX() + wrapW)
+                    ImGui.TextWrapped(text)
+                    ImGui.PopTextWrapPos()
+                    ImGui.Separator()
+                    for order, button in ipairs(buttons) do
+                        if ImGui.Button(button) then
+                            openGUI = false
+                            last_return = order
+                            ImGui.CloseCurrentPopup()
                         end
-                        ImGui.EndPopup()
+                        ImGui.SameLine()
                     end
+                    ImGui.EndPopup()
                 end
-                ImGui.End()
             end
 
             ImGui.Register(title, DisplayModalGUI)

--- a/src/plugins/lua/lua/mq/PackageMan.lua
+++ b/src/plugins/lua/lua/mq/PackageMan.lua
@@ -167,7 +167,7 @@ PackageMan.Require = function(package_name, require_name, fail_message)
     local result_message = nil
     if not my_package then
         if not mq.canDelay() then
-            printf("%s :: package '%s' (require '%s') is not installed and cannot prompt to install. Check how this method is being called.", fail_message, package_name, require_name)
+            printf("%s :: package '%s' (require '%s') is not installed and cannot prompt to install. Ensure the caller is the main script and not a module.", fail_message, package_name, require_name)
             mq.exit()
         end
         my_package, result_message = PackageMan.InstallAndLoad(package_name, require_name)

--- a/src/plugins/lua/lua/mq/PackageMan.lua
+++ b/src/plugins/lua/lua/mq/PackageMan.lua
@@ -166,7 +166,7 @@ PackageMan.Require = function(package_name, require_name, fail_message)
     local my_package = Utils.Library.Include(require_name)
     local result_message = nil
     if not my_package then
-        if not mq.candelay() then
+        if not mq.canDelay() then
             printf("%s :: package '%s' (require '%s') is not installed and cannot prompt to install. Check how this method is being called.", fail_message, package_name, require_name)
             mq.exit()
         end

--- a/src/plugins/lua/lua/mq/PackageMan.lua
+++ b/src/plugins/lua/lua/mq/PackageMan.lua
@@ -166,6 +166,10 @@ PackageMan.Require = function(package_name, require_name, fail_message)
     local my_package = Utils.Library.Include(require_name)
     local result_message = nil
     if not my_package then
+        if not mq.candelay() then
+            printf("%s :: package '%s' (require '%s') is not installed and cannot prompt to install. Check how this method is being called.", fail_message, package_name, require_name)
+            mq.exit()
+        end
         my_package, result_message = PackageMan.InstallAndLoad(package_name, require_name)
     end
     if my_package then


### PR DESCRIPTION
- Fixed an issue where the lua imgui binding for BeginPopupModal was not properly allowing flags
- Added mq.candelay() - returns true if the script is in a state where delay is allowed
- Cleaned up workarounds in PackageMan.lua for the flag issue
- Added a fail state in PackageMan to prevent use if it is in a state that will for sure fail. This is a prospective fix for the blocking issue.
- Added a fail state in ImguiHelper to prevent use in a similar scenario (should not reach from PackageMan, but just in case)