### PR TITLE
WillStackWith - Remove full buff bar check (#793)

### DIFF
--- a/src/main/MQ2Internal.h
+++ b/src/main/MQ2Internal.h
@@ -868,6 +868,20 @@ public:
 
 void RefreshKeyRingWindow();
 
+// RAII guard for stacking queries that target someone other than the local character.
+class ScopedIgnoreBuffBarFullForStacking
+{
+public:
+	ScopedIgnoreBuffBarFullForStacking();
+	~ScopedIgnoreBuffBarFullForStacking();
+
+	ScopedIgnoreBuffBarFullForStacking(const ScopedIgnoreBuffBarFullForStacking&) = delete;
+	ScopedIgnoreBuffBarFullForStacking& operator=(const ScopedIgnoreBuffBarFullForStacking&) = delete;
+
+private:
+	bool m_previous;
+};
+
 //----------------------------------------------------------------------------
 bool GetFilteredModules(HANDLE hProcess, HMODULE* hModule, DWORD cb, DWORD* lpcbNeeded,
 	const std::function<bool(HMODULE)>& filter);

--- a/src/main/MQ2Main.h
+++ b/src/main/MQ2Main.h
@@ -326,6 +326,20 @@ MQLIB_API bool TriggeringEffectSpell(SPELL* aSpell, int i);
 MQLIB_API bool BuffStackTest(SPELL* aSpell, SPELL* bSpell, bool bIgnoreTriggeringEffects = false, bool bTriggeredEffectCheck = false);
 MQLIB_API bool WillStackWith(const EQ_Spell* testSpell, const EQ_Spell* existingSpell);
 MQLIB_API bool IsSpellTooPowerful(PlayerClient* caster, PlayerClient* target, EQ_Spell* spell);
+
+// RAII guard for stacking queries that target someone other than the local character.
+class ScopedIgnoreBuffBarFullForStacking
+{
+public:
+	ScopedIgnoreBuffBarFullForStacking();
+	~ScopedIgnoreBuffBarFullForStacking();
+
+	ScopedIgnoreBuffBarFullForStacking(const ScopedIgnoreBuffBarFullForStacking&) = delete;
+	ScopedIgnoreBuffBarFullForStacking& operator=(const ScopedIgnoreBuffBarFullForStacking&) = delete;
+
+private:
+	bool m_previous;
+};
 MQLIB_API uint32_t GetItemTimer(ItemClient* pItem);
 MQLIB_API ItemClient* GetItemContentsByName(const char* ItemName);
 MQLIB_API DWORD GetAvailableSlots(ItemClient* pContainer, ItemClient* pItem, int *firstavailableslot);

--- a/src/main/MQ2Main.h
+++ b/src/main/MQ2Main.h
@@ -326,7 +326,6 @@ MQLIB_API bool TriggeringEffectSpell(SPELL* aSpell, int i);
 MQLIB_API bool BuffStackTest(SPELL* aSpell, SPELL* bSpell, bool bIgnoreTriggeringEffects = false, bool bTriggeredEffectCheck = false);
 MQLIB_API bool WillStackWith(const EQ_Spell* testSpell, const EQ_Spell* existingSpell);
 MQLIB_API bool IsSpellTooPowerful(PlayerClient* caster, PlayerClient* target, EQ_Spell* spell);
-
 MQLIB_API uint32_t GetItemTimer(ItemClient* pItem);
 MQLIB_API ItemClient* GetItemContentsByName(const char* ItemName);
 MQLIB_API DWORD GetAvailableSlots(ItemClient* pContainer, ItemClient* pItem, int *firstavailableslot);

--- a/src/main/MQ2Main.h
+++ b/src/main/MQ2Main.h
@@ -327,19 +327,6 @@ MQLIB_API bool BuffStackTest(SPELL* aSpell, SPELL* bSpell, bool bIgnoreTriggerin
 MQLIB_API bool WillStackWith(const EQ_Spell* testSpell, const EQ_Spell* existingSpell);
 MQLIB_API bool IsSpellTooPowerful(PlayerClient* caster, PlayerClient* target, EQ_Spell* spell);
 
-// RAII guard for stacking queries that target someone other than the local character.
-class ScopedIgnoreBuffBarFullForStacking
-{
-public:
-	ScopedIgnoreBuffBarFullForStacking();
-	~ScopedIgnoreBuffBarFullForStacking();
-
-	ScopedIgnoreBuffBarFullForStacking(const ScopedIgnoreBuffBarFullForStacking&) = delete;
-	ScopedIgnoreBuffBarFullForStacking& operator=(const ScopedIgnoreBuffBarFullForStacking&) = delete;
-
-private:
-	bool m_previous;
-};
 MQLIB_API uint32_t GetItemTimer(ItemClient* pItem);
 MQLIB_API ItemClient* GetItemContentsByName(const char* ItemName);
 MQLIB_API DWORD GetAvailableSlots(ItemClient* pContainer, ItemClient* pItem, int *firstavailableslot);

--- a/src/main/MQ2Spells.cpp
+++ b/src/main/MQ2Spells.cpp
@@ -4339,12 +4339,40 @@ SpellAttributePredicate<CachedBuff> mq::EvaluateCachedBuffPredicate(std::string_
 
 //============================================================================
 
+static bool s_ignoreBuffBarFullForStacking = false;
+
+class CharacterZoneClient_StackHook
+{
+public:
+	DETOUR_TRAMPOLINE_DEF(int, GetOpenEffectSlot_Trampoline, (bool, bool, int))
+	int GetOpenEffectSlot_Detour(bool bIsShortBuff, bool bIsMeleeSkill, int Index)
+	{
+		if (s_ignoreBuffBarFullForStacking)
+			return reinterpret_cast<CharacterZoneClient*>(this)->GetFirstEffectSlot(bIsShortBuff, bIsMeleeSkill);
+
+		return GetOpenEffectSlot_Trampoline(bIsShortBuff, bIsMeleeSkill, Index);
+	}
+};
+
+ScopedIgnoreBuffBarFullForStacking::ScopedIgnoreBuffBarFullForStacking()
+	: m_previous(s_ignoreBuffBarFullForStacking)
+{
+	s_ignoreBuffBarFullForStacking = true;
+}
+
+ScopedIgnoreBuffBarFullForStacking::~ScopedIgnoreBuffBarFullForStacking()
+{
+	s_ignoreBuffBarFullForStacking = m_previous;
+}
+
 static void InitializeSpells()
 {
+	EzDetour(CharacterZoneClient__GetOpenEffectSlot, &CharacterZoneClient_StackHook::GetOpenEffectSlot_Detour, &CharacterZoneClient_StackHook::GetOpenEffectSlot_Trampoline);
 }
 
 static void ShutdownSpells()
 {
+	RemoveDetour(CharacterZoneClient__GetOpenEffectSlot);
 }
 
 static void PulseSpells()

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -4823,6 +4823,10 @@ bool BuffStackTest(SPELL* aSpell, SPELL* bSpell, bool bIgnoreTriggeringEffects, 
  * Takes two spells in order to test if they will stack. Any null checking should be
  * done before this function is called, assumes all values are non-null.
  *
+ * This briefly disables the buff bar full check so that the buff bar being full
+ * on the current character does not cause this function to return false when it
+ * otherwise would return true.
+ *
  * @param testSpell The spell that would hypothetically be cast (non-null)
  * @param existingSpell The spell that would hypothetically already exist (non-null)
  *
@@ -4841,6 +4845,10 @@ bool WillStackWith(const EQ_Spell* testSpell, const EQ_Spell* existingSpell)
 	buff.PopulateFromSpell(existingSpell);
 
 	int SlotIndex = -1;
+
+	// Callers of WillStackWith are not concerned with the current character's buff bar capacity
+	ScopedIgnoreBuffBarFullForStacking ignoreBuffBarFull;
+
 	EQ_Affect* ret = pLocalPC->FindAffectSlot(testSpell->ID, pLocalPlayer, &SlotIndex, true, pLocalPlayer->Level, &buff, 1);
 
 	return ret && SlotIndex != -1;


### PR DESCRIPTION
- Fixes #793
- Part of the client logic for FindAffectSlot is to check if the buff bar is full and gate on that. This change temporarily disables that check when we're running a WillStackWith check, since we never care about that situation.