### PR TITLE
Deprecate "Mage" and "Shadowknight" matching (#155)

### DIFF
--- a/src/loader/LoaderAutoLogin.cpp
+++ b/src/loader/LoaderAutoLogin.cpp
@@ -24,6 +24,8 @@
 #include "mq/base/Config.h"
 #include "mq/base/String.h"
 
+#include "eqlib/game/ClassInfo.h"
+
 #include "fmt/format.h"
 #include "fmt/os.h"
 #include "spdlog/spdlog.h"
@@ -49,38 +51,11 @@ namespace internal_paths
 	std::string s_autoLoginIni;
 }
 
-// need a map of shortname to name (TODO: Use long names in the display)
-// order matters here in the logic, so we need to make sure these are in the same order as MQ2
-struct SClassInfo
-{
-	const char* Name;
-	const char* UCShortName;
-};
-
-static SClassInfo s_classInfo[] =
-{
-	{ "",             ""    },
-	{ "Warrior",      "WAR" },
-	{ "Cleric",       "CLR" },
-	{ "Paladin",      "PAL" },
-	{ "Ranger",       "RNG" },
-	{ "Shadowknight", "SHD" },
-	{ "Druid",        "DRU" },
-	{ "Monk",         "MNK" },
-	{ "Bard",         "BRD" },
-	{ "Rogue",        "ROG" },
-	{ "Shaman",       "SHM" },
-	{ "Necromancer",  "NEC" },
-	{ "Wizard",       "WIZ" },
-	{ "Mage",         "MAG" },
-	{ "Enchanter",    "ENC" },
-	{ "Beastlord",    "BST" },
-	{ "Berserker",    "BER" },
-};
-
 const char* GetClassShortName(const DWORD player_class)
 {
-	return s_classInfo[player_class].UCShortName;
+	if (player_class >= std::size(eqlib::ClassInfo))
+		return eqlib::ClassInfo[0].UCShortName;
+	return eqlib::ClassInfo[player_class].UCShortName;
 }
 
 void Post(uint32_t pid, const proto::login::MessageId& messageId, const std::string& data)

--- a/src/main/MQ2Spells.cpp
+++ b/src/main/MQ2Spells.cpp
@@ -3699,11 +3699,25 @@ int GetPlayerClass(std::string_view name)
 	auto player_class = std::find_if(std::cbegin(ClassInfo), std::cend(ClassInfo),
 		[name](const SClassInfo& info)
 		{
-			return ci_equals(info.ShortName, name) || ci_equals(info.Name, name);
+			return ci_equals(info.ShortName, name) || ci_equals(info.LongName, name);
 		});
 
 	if (player_class != std::cend(ClassInfo))
 		return static_cast<int>(std::distance(std::cbegin(ClassInfo), player_class));
+
+	// Fall back to the deprecated legacy name, announcing its deprecation.
+	player_class = std::find_if(std::cbegin(ClassInfo), std::cend(ClassInfo),
+		[name](const SClassInfo& info)
+		{
+#pragma warning(suppress : 4996) // ClassInfo.Name is deprecated, but we're announcing its deprecation here
+			return ci_equals(info.Name, name);
+		});
+
+	if (player_class != std::cend(ClassInfo))
+	{
+		WriteChatf("\ayWARNING: SpellFilter: Matching a class by \"%.*s\" is deprecated; use \"%s\" instead.\ax", static_cast<int>(name.size()), name.data(), player_class->LongName);
+		return static_cast<int>(std::distance(std::cbegin(ClassInfo), player_class));
+	}
 
 	return 0;
 }

--- a/src/main/MQ2Utilities.cpp
+++ b/src/main/MQ2Utilities.cpp
@@ -3642,7 +3642,7 @@ const char* ParseSearchSpawnArgs(char* szArg, const char* szRest, MQSpawnSearch*
 			pSearchSpawn->yLoc = GetFloatFromString(szArg, 0);
 			GetArg(szArg, szRest, 3);
 			pSearchSpawn->zLoc = GetFloatFromString(szArg, 0);
-			if (pSearchSpawn->zLoc == 0.0)
+			if (pSearchSpawn->zLoc == 0.0 && pControlledPlayer)
 			{
 				pSearchSpawn->zLoc = pControlledPlayer->Z;
 				szRest = GetNextArg(szRest, 2);
@@ -3709,7 +3709,10 @@ const char* ParseSearchSpawnArgs(char* szArg, const char* szRest, MQSpawnSearch*
 		}
 		else if (!_stricmp(szArg, "guild"))
 		{
-			pSearchSpawn->GuildID = pLocalPC->GuildID;
+			if (pLocalPC)
+			{
+				pSearchSpawn->GuildID = pLocalPC->GuildID;
+			}
 		}
 		else if (!_stricmp(szArg, "guildname"))
 		{
@@ -3792,12 +3795,23 @@ const char* ParseSearchSpawnArgs(char* szArg, const char* szRest, MQSpawnSearch*
 		}
 		else
 		{
-			for (int index = 1; index < (int)lengthof(ClassInfo) - 1; index++)
+			if (pEverQuest)
 			{
-				if (!_stricmp(szArg, ClassInfo[index].Name) || !_stricmp(szArg, ClassInfo[index].ShortName))
+				for (int index = 1; index < static_cast<int>(lengthof(ClassInfo)) - 1; index++)
 				{
-					strcpy_s(pSearchSpawn->szClass, pEverQuest->GetClassDesc(index));
-					return szRest;
+					if (!_stricmp(szArg, pEverQuest->GetClassDesc(index)) || !_stricmp(szArg, ClassInfo[index].ShortName))
+					{
+						strcpy_s(pSearchSpawn->szClass, pEverQuest->GetClassDesc(index));
+						return szRest;
+					}
+
+#pragma warning(suppress : 4996) // ClassInfo.Name is deprecated, but we're announcing its deprecation here
+					if (!_stricmp(szArg, ClassInfo[index].Name))
+					{
+						strcpy_s(pSearchSpawn->szClass, pEverQuest->GetClassDesc(index));
+						WriteChatf("\ayWARNING: SpawnSearch: Matching a class by \"%s\" is deprecated; use \"%s\" instead.\ax", szArg, pEverQuest->GetClassDesc(index));
+						return szRest;
+					}
 				}
 			}
 
@@ -3826,6 +3840,21 @@ void ParseSearchSpawn(const char* Buffer, MQSpawnSearch* pSearchSpawn)
 {
 	bRunNextCommand = true;
 	const char* szFilter = Buffer;
+
+	// A class long name can contain a space (e.g. "Shadow Knight"), and "knight" is itself a
+	// spawn-search keyword. If the whole search string is a class long name, tokenizing it would
+	// mis-parse it (name "shadow" + the "knight" keyword), so match it as a class search up front.
+	if (pEverQuest && Buffer[0] != '\0')
+	{
+		for (int index = 1; index < static_cast<int>(lengthof(ClassInfo)) - 1; index++)
+		{
+			if (!_stricmp(Buffer, pEverQuest->GetClassDesc(index)))
+			{
+				strcpy_s(pSearchSpawn->szClass, pEverQuest->GetClassDesc(index));
+				return;
+			}
+		}
+	}
 
 	char szArg[MAX_STRING] = { 0 };
 


### PR DESCRIPTION
- Fixes #155
- Fixes #156
- ClassInfo previously had "Mage" and "Shadowknight" entries instead of "Magician" and "Shadow Knight" leading to inconsistencies in spawn searches since you couldn't use the actual class names.
- While fixing this, added some guards in SpawnSearch where crashes could occur due to the expectation a SpawnSearch would only be performed in game
- LongName was added to eqlib as a backwards compatible shim to avoid breaking existing code, and warnings will be emitted when the corresponding old class names are matched in MQ
- Since the loader is just accepting whatever is sent from MQ, added a bounds check against ClassInfo's size and deduplicated the ClassInfo array. This does come with an issue where if MQ was built against a different eqlib, you could be in a situation where they don't match, but it's unlikely and other items would need to be handled in that scenario anyway.