### PR TITLE
Persist the Loader UI state between sessions

### DIFF
--- a/src/imgui/ImGuiTreePanelWindow.h
+++ b/src/imgui/ImGuiTreePanelWindow.h
@@ -168,6 +168,16 @@ public:
 		}
 	}
 
+	std::string_view GetSelectedPanel() const
+	{
+		if (m_selectedPanel != nullptr)
+		{
+			return std::string_view(m_selectedPanel->name);
+		}
+
+		return std::string_view();
+	}
+
 private:
 	void RegenerateTree()
 	{

--- a/src/loader/ImGui.cpp
+++ b/src/loader/ImGui.cpp
@@ -22,11 +22,15 @@
 #include "imgui/ImGuiTreePanelWindow.h"
 #include "login/AutoLogin.h"
 
+#include "mq/base/Config.h"
 #include "spdlog/spdlog.h"
 
  // map of panels in the main GUI window
 static mq::imgui::ImGuiTreePanelWindow* s_mainWindow = nullptr;
 static std::map<const char*, void(*)()> s_pendingPanels;
+
+// last selected panel we wrote to the ini so we can gate writes on changes
+static std::string s_lastPersistedPanel;
 
 // map of viewport windows to render
 static std::map<std::string, std::function<bool()>> s_viewports;
@@ -372,6 +376,10 @@ void Run(const std::function<bool()>& mainLoop)
 
 	s_pendingPanels.clear();
 
+	// Restore the UI window if it was open last exit
+	if (const std::string panel = mq::GetPrivateProfileString("MacroQuest", "MainWindowPanel", "", internal_paths::MQini); !panel.empty())
+		SelectMainPanel(panel);
+
 	s_iniFilename = (std::filesystem::path{ internal_paths::Config } / "MacroQuest_LauncherUI.ini").string();
 	s_logFilename = (std::filesystem::path{ internal_paths::Logs } / "MacroQuest_LauncherUI.log").string();
 	Backend::Init(hMainWnd, s_iniFilename.c_str(), s_logFilename.c_str());
@@ -431,7 +439,16 @@ void Run(const std::function<bool()>& mainLoop)
 
 				ImGui::SetNextWindowClass(&s_viewportClass);
 				if (!it->second())
+				{
+					// Clear the saved panel so we don't reopen next run.
+					if (it->first == "MacroQuest")
+					{
+						s_lastPersistedPanel.clear();
+						mq::WritePrivateProfileString("MacroQuest", "MainWindowPanel", "", internal_paths::MQini);
+					}
+
 					it = s_viewports.erase(it);
+				}
 				else
 					++it;
 			}
@@ -495,7 +512,15 @@ void OpenMainWindow()
 			ImGui::SetNextWindowPos(monitor->WorkPos + (monitor->WorkSize * 0.5f), ImGuiCond_FirstUseEver, { 0.5f, 0.5f });
 
 			if (s_mainWindow != nullptr)
+			{
 				s_mainWindow->Draw(&is_open);
+
+				if (const std::string_view panel = s_mainWindow->GetSelectedPanel(); !panel.empty() && panel != s_lastPersistedPanel)
+				{
+					s_lastPersistedPanel = std::string(panel);
+					mq::WritePrivateProfileString("MacroQuest", "MainWindowPanel", s_lastPersistedPanel, internal_paths::MQini);
+				}
+			}
 
 			ImGui::PopStyleVar();
 

--- a/src/loader/ImGui.cpp
+++ b/src/loader/ImGui.cpp
@@ -32,6 +32,9 @@ static std::map<const char*, void(*)()> s_pendingPanels;
 // last selected panel we wrote to the ini so we can gate writes on changes
 static std::string s_lastPersistedPanel;
 
+// whether we persist/restore the main window panel between sessions
+static bool s_persistMainWindow = true;
+
 // map of viewport windows to render
 static std::map<std::string, std::function<bool()>> s_viewports;
 static std::optional<std::string> s_focusViewport;
@@ -352,6 +355,27 @@ void RemoveMainPanel(const char* name)
 		s_mainWindow->RemovePanel(name);
 }
 
+bool GetPersistMainWindow()
+{
+	return s_persistMainWindow;
+}
+
+void SetPersistMainWindow(bool persist)
+{
+	if (persist != s_persistMainWindow)
+	{
+		s_persistMainWindow = persist;
+		mq::WritePrivateProfileBool("MacroQuest", "PersistMainWindow", persist, internal_paths::MQini);
+
+		if (!persist)
+		{
+			// Forget any saved panels
+			s_lastPersistedPanel.clear();
+			mq::WritePrivateProfileString("MacroQuest", "MainWindowPanel", "", internal_paths::MQini);
+		}
+	}
+}
+
 bool AddContextGroup(const std::string& name, const std::function<void()>& callback)
 {
 	s_menus.emplace_back(name, callback);
@@ -382,9 +406,13 @@ void Run(const std::function<bool()>& mainLoop)
 
 	s_pendingPanels.clear();
 
-	// Restore the UI window if it was open last exit
-	if (const std::string panel = mq::GetPrivateProfileString("MacroQuest", "MainWindowPanel", "", internal_paths::MQini); !panel.empty())
-		SelectMainPanel(panel);
+	// Restore the UI window if it was open last exit (when enabled in UI Settings)
+	s_persistMainWindow = mq::GetPrivateProfileBool("MacroQuest", "PersistMainWindow", true, internal_paths::MQini);
+	if (s_persistMainWindow)
+	{
+		if (const std::string panel = mq::GetPrivateProfileString("MacroQuest", "MainWindowPanel", "", internal_paths::MQini); !panel.empty())
+			SelectMainPanel(panel);
+	}
 
 	s_iniFilename = (std::filesystem::path{ internal_paths::Config } / "MacroQuest_LauncherUI.ini").string();
 	s_logFilename = (std::filesystem::path{ internal_paths::Logs } / "MacroQuest_LauncherUI.log").string();
@@ -521,10 +549,13 @@ void OpenMainWindow()
 			{
 				s_mainWindow->Draw(&is_open);
 
-				if (const std::string_view panel = s_mainWindow->GetSelectedPanel(); !panel.empty() && panel != s_lastPersistedPanel)
+				if (s_persistMainWindow)
 				{
-					s_lastPersistedPanel = std::string(panel);
-					mq::WritePrivateProfileString("MacroQuest", "MainWindowPanel", s_lastPersistedPanel, internal_paths::MQini);
+					if (const std::string_view panel = s_mainWindow->GetSelectedPanel(); !panel.empty() && panel != s_lastPersistedPanel)
+					{
+						s_lastPersistedPanel = std::string(panel);
+						mq::WritePrivateProfileString("MacroQuest", "MainWindowPanel", s_lastPersistedPanel, internal_paths::MQini);
+					}
 				}
 			}
 

--- a/src/loader/ImGui.h
+++ b/src/loader/ImGui.h
@@ -37,6 +37,8 @@ void OpenWindow(
 void SelectMainPanel(const std::string& name);
 void AddMainPanel(const char* name, void(*callback)());
 void RemoveMainPanel(const char* name);
+bool GetPersistMainWindow();
+void SetPersistMainWindow(bool persist);
 bool AddContextGroup(const std::string& name, const std::function<void()>& callback);
 bool RemoveContextGroup(const std::string& name);
 void Run(const std::function<bool()>& mainLoop);

--- a/src/loader/MacroQuest.cpp
+++ b/src/loader/MacroQuest.cpp
@@ -585,6 +585,26 @@ void ShowLoggingSettings()
 	}
 }
 
+void ShowUISettings()
+{
+	ImGui::PushFont(mq::imgui::LargeTextFont);
+	ImGui::Text("User Interface");
+	ImGui::PopFont();
+	ImGui::Separator();
+
+	bool showConsole = gbConsoleVisible;
+	if (ImGui::Checkbox("Show Debug Console", &showConsole))
+		UpdateShowConsole(showConsole, true);
+	ImGui::SameLine();
+	mq::imgui::HelpMarker("Shows or hides the MacroQuest loader debug console window.");
+
+	bool persist = LauncherImGui::GetPersistMainWindow();
+	if (ImGui::Checkbox("Persist UI State", &persist))
+		LauncherImGui::SetPersistMainWindow(persist);
+	ImGui::SameLine();
+	mq::imgui::HelpMarker("When enabled, if the MacroQuest Loader UI (this window) is open when the loader closes, it reopens to the same place on the next launch.");
+}
+
 #pragma endregion
 
 #pragma region Paths and Configuration
@@ -1378,6 +1398,7 @@ void InitializeWindows()
 	LauncherImGui::AddMainPanel("MacroQuest Info", ShowMacroQuestInfo);
 	LauncherImGui::AddMainPanel("Logging", ShowLoggingSettings);
 	LauncherImGui::AddMainPanel("Processes", ShowProcessInfo);
+	LauncherImGui::AddMainPanel("UI Settings", ShowUISettings);
 	LauncherImGui::AddContextGroup("##MacroQuest", ShowMacroQuestMenu);
 }
 


### PR DESCRIPTION
- Adds the last session panel to the ini
- Clears it if the Main UI window is closed
- Upon relaunch, loads the last state