### PR TITLE
Fix buffer overflow in ${String[...].Right[N]} when N exceeds string length

### DIFF
--- a/src/main/datatypes/MQ2BasicTypes.cpp
+++ b/src/main/datatypes/MQ2BasicTypes.cpp
@@ -511,10 +511,14 @@ bool MQ2StringType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 			}
 			else
 			{
-				pStart = &pStart[strlen(pStart) - Len];
+				// Clamp Len to the source length. Otherwise strlen(pStart) - Len underflows
+				// (size_t wrap), and although pStart is clamped back to szString below, Len
+				// stays huge and memmove copies Len + 1 bytes past the end of the fixed
+				// DataTypeTemp buffer -> memory corruption. Mirrors the .Left handling above.
+				if (static_cast<size_t>(Len) > StrLen)
+					Len = static_cast<int>(StrLen);
 
-				if (pStart < szString)
-					pStart = szString;
+				pStart = &pStart[StrLen - Len];
 
 				memmove(DataTypeTemp, pStart, Len + 1);
 				Dest.Ptr = &DataTypeTemp[0];

--- a/src/main/datatypes/MQ2BasicTypes.cpp
+++ b/src/main/datatypes/MQ2BasicTypes.cpp
@@ -492,6 +492,9 @@ bool MQ2StringType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 			if (Len == 0)
 				return false;
 
+			if (Len > MAX_STRING - 1)
+				Len = MAX_STRING - 1;
+
 			if (Len < 0)
 			{
 				Len = -Len;
@@ -511,10 +514,6 @@ bool MQ2StringType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 			}
 			else
 			{
-				// Clamp Len to the source length. Otherwise strlen(pStart) - Len underflows
-				// (size_t wrap), and although pStart is clamped back to szString below, Len
-				// stays huge and memmove copies Len + 1 bytes past the end of the fixed
-				// DataTypeTemp buffer -> memory corruption. Mirrors the .Left handling above.
 				if (static_cast<size_t>(Len) > StrLen)
 					Len = static_cast<int>(StrLen);
 


### PR DESCRIPTION
### Summary
`${String[...].Right[N]}` can overflow the fixed 2048-byte `DataTypeTemp` global buffer when `N` is larger than the string length.

### Details
In `StringMembers::Right` (positive-`N` branch), `Len` is never clamped to the source length before the copy:

```cpp
pStart = &pStart[strlen(pStart) - Len];   // strlen - Len underflows when Len > strlen
if (pStart < szString)                     // pStart is clamped back...
    pStart = szString;
memmove(DataTypeTemp, pStart, Len + 1);    // ...but Len is still huge -> writes past DataTypeTemp
```

When `Len > strlen(pStart)`, the `size_t` subtraction wraps, `pStart` is clamped back to `szString`, but `Len` stays huge — so `memmove` copies `Len + 1` bytes into the 2048-byte `DataTypeTemp`. For example `${String[abc].Right[5000]}` copies 5001 bytes into a 2048-byte buffer: global memory corruption / crash, reachable from any macro.

### Fix
Clamp `Len` to `StrLen` (already computed/in scope in this member) before computing the start pointer, mirroring how the adjacent `.Left` member already handles it. After clamping, `StrLen - Len` is non-negative and `memmove` copies exactly the trailing `Len` chars plus the null terminator.

No client-version or eqlib coupling; behavior is unchanged for valid `N`.
