### PR TITLE
Fix hotkey name for the V key returning B

### DIFF
--- a/src/common/HotKeys.cpp
+++ b/src/common/HotKeys.cpp
@@ -331,7 +331,7 @@ const char* GetKeyNameFromVirtualKey(uint16_t virtualKey)
 	case 'S': return "S";
 	case 'T': return "T";
 	case 'U': return "U";
-	case 'V': return "B";
+	case 'V': return "V";
 	case 'W': return "W";
 	case 'X': return "X";
 	case 'Y': return "Y";


### PR DESCRIPTION
### Bug

`GetKeyNameFromVirtualKey`'s A–Z mapping in `src/common/HotKeys.cpp` has a typo: `case 'V'` returns `"B"`.

```cpp
case 'U': return "U";
case 'V': return "B";   // <-- should be "V"
case 'W': return "W";
```

Every other letter maps to itself; any hotkey bound to the **V** key is displayed/serialized as **B**.

### Fix

One character: return `"V"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
