### PR TITLE
MQ2HUD: use SY for the Y screen offset, not SX

### DIFF
--- a/src/plugins/hud/MQ2HUD.cpp
+++ b/src/plugins/hud/MQ2HUD.cpp
@@ -624,7 +624,7 @@ PLUGIN_API void OnDrawHUD()
 			else
 			{
 				X = SX + pElement->X;
-				Y = SX + pElement->Y;
+				Y = SY + pElement->Y;
 			}
 
 			if (bCheckParse)


### PR DESCRIPTION
### Bug

In `src/plugins/hud/MQ2HUD.cpp`, non-cursor HUD elements add the **horizontal** screen offset to **both** coordinates:

```cpp
X = SX + pElement->X;
Y = SX + pElement->Y;   // <-- should be SY
```

`SY` is assigned from `ScreenY` a few lines above and is otherwise never read — which is the tell that `SX` on the Y line is a copy-paste slip rather than intent. Whenever the two screen offsets differ, every `HUDTYPE_NORMAL`/`HUDTYPE_FULLSCREEN` element lands at the wrong vertical position (the cursor-anchored branch just above uses X/Y correctly).

### Fix

One character: `Y = SY + pElement->Y;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
