### PR TITLE
Return NULL for empty XTarget slots instead of a stale name

### DIFF
--- a/src/main/datatypes/MQ2XTargetType.cpp
+++ b/src/main/datatypes/MQ2XTargetType.cpp
@@ -103,11 +103,13 @@ bool MQ2XTargetType::ToString(MQVarPtr VarPtr, char* Destination)
 		&& xts->XTargetSlotStatus != eXTSlotEmpty)
 	{
 		strcpy_s(Destination, MAX_STRING, xts->Name);
-		return true;
+	}
+	else
+	{
+		strcpy_s(Destination, MAX_STRING, "NULL");
 	}
 
-	strcpy_s(Destination, MAX_STRING, "NULL");
-	return false;
+	return true;
 }
 
 bool MQ2XTargetType::Downcast(const MQVarPtr& fromVar, MQVarPtr& toVar, MQ2Type* toType)

--- a/src/main/datatypes/MQ2XTargetType.cpp
+++ b/src/main/datatypes/MQ2XTargetType.cpp
@@ -65,7 +65,7 @@ bool MQ2XTargetType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index,
 		return true;
 
 	case XTargetMembers::Name:
-		if (xts->Name[0] != 0)
+		if (xts->XTargetSlotStatus != eXTSlotEmpty && xts->Name[0] != 0)
 			strcpy_s(DataTypeTemp, xts->Name);
 		else
 			strcpy_s(DataTypeTemp, "NULL");
@@ -99,16 +99,15 @@ bool MQ2XTargetType::ToString(MQVarPtr VarPtr, char* Destination)
 	ExtendedTargetSlot* xts = nullptr;
 
 	if (pLocalPC
-		&& (xts = pLocalPC->pExtendedTargetList->GetSlot(index)))
+		&& (xts = pLocalPC->pExtendedTargetList->GetSlot(index))
+		&& xts->XTargetSlotStatus != eXTSlotEmpty)
 	{
 		strcpy_s(Destination, MAX_STRING, xts->Name);
-	}
-	else
-	{
-		strcpy_s(Destination, MAX_STRING, "NULL");
+		return true;
 	}
 
-	return true;
+	strcpy_s(Destination, MAX_STRING, "NULL");
+	return false;
 }
 
 bool MQ2XTargetType::Downcast(const MQVarPtr& fromVar, MQVarPtr& toVar, MQ2Type* toType)


### PR DESCRIPTION
Fixes #918

### Bug

When an XTarget slot empties, the client clears `SpawnID` and sets `XTargetSlotStatus = eXTSlotEmpty` — but it does **not** clear the `Name` buffer. The xtarget datatype reads `xts->Name` unconditionally, so `${Me.XTarget[1]}` / `mq.TLO.Me.XTarget(1)()` keeps returning the previous occupant's name instead of NULL (as reported and diagnosed in the issue).

### Fix

Guard both readers with the same `XTargetSlotStatus != eXTSlotEmpty` test the codebase already uses as the canonical slot-emptiness check (`MQ2CharacterType.cpp`, `MQ2Utilities.cpp` GetAuraSpawnName):

- **`Name` member** — empty slot now takes the existing `"NULL"` fallback branch.
- **`ToString`** — empty slot now writes `"NULL"` instead of the stale name. Per review, ToString keeps its always-return-true contract.

`eXTSlotDifferentZone` slots (e.g. a group member in another zone: valid name, `SpawnID` 0) intentionally still return the name — only `eXTSlotEmpty` is excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
