### PR TITLE
Remove broken Me.AltTimerReady member

### DIFF
--- a/src/main/datatypes/MQ2CharacterType.cpp
+++ b/src/main/datatypes/MQ2CharacterType.cpp
@@ -105,7 +105,6 @@ enum class CharacterMembers
 	CopperBank,
 	Stunned,
 	RangedReady,
-	AltTimerReady,
 	MaxEndurance,
 	PctEndurance,
 	AltAbility,
@@ -452,7 +451,6 @@ MQ2CharacterType::MQ2CharacterType() : MQ2Type("character")
 	ScopedTypeMember(CharacterMembers, CopperBank);
 	ScopedTypeMember(CharacterMembers, Stunned);
 	ScopedTypeMember(CharacterMembers, RangedReady);
-	ScopedTypeMember(CharacterMembers, AltTimerReady);
 	ScopedTypeMember(CharacterMembers, MaxEndurance);
 	ScopedTypeMember(CharacterMembers, PctEndurance);
 	ScopedTypeMember(CharacterMembers, AltAbility);
@@ -2073,11 +2071,6 @@ bool MQ2CharacterType::GetMember(MQVarPtr VarPtr, const char* Member, char* Inde
 
 	case CharacterMembers::RangedReady:
 		Dest.Set(pEverQuestInfo->PrimaryAttackReady != 0);
-		Dest.Type = pBoolType;
-		return true;
-
-	case CharacterMembers::AltTimerReady:
-		Dest.Set(true); // this is broken and should be fixed or removed.
 		Dest.Type = pBoolType;
 		return true;
 


### PR DESCRIPTION
Fixes #339

### Bug

`${Me.AltTimerReady}` always returns TRUE — the member is a stub:

```cpp
case CharacterMembers::AltTimerReady:
    Dest.Set(true); // this is broken and should be fixed or removed.
    Dest.Type = pBoolType;
    return true;
```

### Fix

Removed, per @Knightly1's comment on the issue ("`AbilityReady` replaces it completely… my vote is that we just remove it rather than deprecate it"): enum entry, `ScopedTypeMember` registration, and the case block. Members are resolved by name string at runtime and the enum is file-local, so the removal is self-contained; `${Me.AltTimerReady}` now resolves to NULL like any unknown member instead of silently returning a bogus TRUE.

The only other in-repo reference is a historical 2005 CHANGELOG entry, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
