### PR TITLE
Window List: only treat a comma as a column selector when numeric

### DIFF
--- a/src/main/datatypes/MQ2WindowType.cpp
+++ b/src/main/datatypes/MQ2WindowType.cpp
@@ -565,13 +565,21 @@ bool MQ2WindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 		}
 
 		int nColumn = 0;
-		if (char* pComma = strchr(Index, ','))
+
+		// The index can optionally select a column with a ", #" suffix. Only treat the
+		// comma as a column separator when the text following it is a number, because
+		// list item text can itself contain commas (#425).
+		if (char* pComma = strrchr(Index, ','))
 		{
-			nColumn = GetIntFromString(&pComma[1], nColumn) - 1;
-			if (nColumn < 0) nColumn = 0;
-			if (nColumn >= pListWnd->Columns.GetCount())
-				return false;
-			*pComma = '\0';
+			int nSpecifiedColumn = GetIntFromString(&pComma[1], INT_MIN);
+			if (nSpecifiedColumn != INT_MIN)
+			{
+				nColumn = nSpecifiedColumn - 1;
+				if (nColumn < 0) nColumn = 0;
+				if (nColumn >= pListWnd->Columns.GetCount())
+					return false;
+				*pComma = '\0';
+			}
 		}
 
 		if (IsNumber(Index))


### PR DESCRIPTION
Fixes #425

### Bug

`${Window[TradeskillWnd].Child[RecipeList].List[=Xril'et Log, Page 9]}` can never match. The `List` index parser unconditionally truncates at the **first** comma and parses the remainder as a column number:

```cpp
if (char* pComma = strchr(Index, ','))
{
    nColumn = GetIntFromString(&pComma[1], nColumn) - 1;  // " Page 9" -> 0
    ...
    *pComma = '\0';                                       // needle becomes "=Xril'et Log"
}
```

Quoting can't work around it: `ParseMQ2DataPortion` strips double quotes from bracket indices before the type member ever sees them, so quoted and unquoted commas arrive identically.

### Fix

The `strrchr` approach suggested in the issue thread: take the **last** comma, and only consume the suffix as a column selector when it actually parses as a number.

- `List[text,2]` / `List[text, 2]` — byte-identical behavior, including the historical clamp of `,0`/negative to column 0.
- `List[text, with comma]` — comma now stays part of the search text (the bug).
- `List[text, with comma,2]` — still selects column 2.

Item text genuinely ending in `", <number>"` remains ambiguous with the column syntax, same as today — unavoidable without a syntax break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
