### PR TITLE
Fix crash when Window.Text exceeds the data buffer

### DIFF
--- a/src/main/datatypes/MQ2WindowType.cpp
+++ b/src/main/datatypes/MQ2WindowType.cpp
@@ -504,16 +504,16 @@ bool MQ2WindowType::GetMember(MQVarPtr VarPtr, const char* Member, char* Index, 
 		if (pWnd->GetType() == UI_STMLBox)
 		{
 			CStmlWnd* cstmlwnd = static_cast<CStmlWnd*>(pWnd);
-			strcpy_s(DataTypeTemp, cstmlwnd->GetSTMLText().c_str());
+			strncpy_s(DataTypeTemp, cstmlwnd->GetSTMLText().c_str(), _TRUNCATE);
 		}
 		else if (pWnd->GetType() == UI_Page)
 		{
 			CPageWnd* pPageWnd = static_cast<CPageWnd*>(pWnd);
-			strcpy_s(DataTypeTemp, pPageWnd->TabText.c_str());
+			strncpy_s(DataTypeTemp, pPageWnd->TabText.c_str(), _TRUNCATE);
 		}
 		else
 		{
-			strcpy_s(DataTypeTemp, pWnd->GetWindowText().c_str());
+			strncpy_s(DataTypeTemp, pWnd->GetWindowText().c_str(), _TRUNCATE);
 		}
 
 		Dest.Ptr = &DataTypeTemp[0];


### PR DESCRIPTION
Fixes #300

### Bug

`${Window[BazaarWnd].Child[BZW_BazaarText].Text}` (or any window whose text exceeds 2048 characters) crashes to desktop. `DataTypeTemp` is a fixed `SGlobalBuffer` of 2048 bytes, and `strcpy_s` with a longer source invokes the CRT invalid-parameter handler, which terminates the process — a guaranteed CTD whenever `GetSTMLText()`/`GetWindowText()`/`TabText` returns ≥ 2048 chars (bazaar trader mode easily does).

### Fix

Use the existing `strncpy_s(SGlobalBuffer&, const char*, _TRUNCATE)` helper in all three branches of `WindowMembers::Text` — the same pattern already used by `GetCXStr` (`MQ2Inlines.h`) and `EmuExtensions.cpp`. Short text is bit-identical to before; long text now truncates to the established MAX_STRING semantics for datatype strings instead of killing the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
