### PR TITLE
Unlink timed commands before executing them

### DIFF
--- a/src/main/MQCommandAPI.cpp
+++ b/src/main/MQCommandAPI.cpp
@@ -891,11 +891,17 @@ void MQCommandAPI::PulseCommands()
 
 	while (m_pTimedCommands && m_pTimedCommands->time <= Now)
 	{
-		MQTimedCommand* pNext = m_pTimedCommands->pNext;
-		DoCommand(m_pTimedCommands->command.c_str(), false, m_pTimedCommands->pluginHandle);
+		MQTimedCommand* pTimedCommand = m_pTimedCommands;
 
-		delete m_pTimedCommands;
-		m_pTimedCommands = pNext;
+		// Unlink the command from the list before executing it. Executing the command
+		// may schedule new timed commands, which would modify the list.
+		m_pTimedCommands = pTimedCommand->pNext;
+		if (m_pTimedCommands)
+			m_pTimedCommands->pLast = nullptr;
+
+		DoCommand(pTimedCommand->command.c_str(), false, pTimedCommand->pluginHandle);
+
+		delete pTimedCommand;
 	}
 }
 


### PR DESCRIPTION
Fixes #434

### Bug

`/timed 5 /myalias` where the alias expands to more `/timed` commands: the nested timed commands never execute.

The drain loop in `MQCommandAPI::PulseCommands()` captures `pNext` **before** running the due command, while that node is still linked as the list head:

```cpp
MQTimedCommand* pNext = m_pTimedCommands->pNext;
DoCommand(m_pTimedCommands->command.c_str(), ...);   // may insert new nodes after the still-linked head
delete m_pTimedCommands;
m_pTimedCommands = pNext;                            // stale -> newly inserted nodes orphaned/leaked
```

`DoCommand` synchronously expands the alias → multiline → `DoTimedCmd` → `TimedCommand()`, which inserts the new nodes after the still-linked head (its due time ≤ Now skips the head-insert branch). Restoring the stale `pNext` then orphans everything inserted during execution; in the equal-timestamp case the loop can even delete the wrong node.

### Fix

Unlink the due node from the list **before** executing it — the same swap-before-execute pattern this function already uses for `m_delayedCommands`. Insertions during execution now land on the real list head and fire normally. The recursive `m_commandMutex` makes the nested `TimedCommand` call safe; nothing else traverses this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
