### PR TITLE
/itemnotify: select tribute donations instead of picking up the item

### DIFF
--- a/src/main/MQ2Windows.cpp
+++ b/src/main/MQ2Windows.cpp
@@ -1467,6 +1467,25 @@ void ItemNotify(PSPAWNINFO pChar, char* szLine)
 					return;
 				}
 
+				// If the tribute master window is open, a left click should select the item as
+				// a donation instead of picking it up. That requires a real click on the slot's
+				// window, so open the container and send the click to it. The container is left
+				// open so that the selection remains valid until the donation is made.
+				if (pTributeMasterWnd && pTributeMasterWnd->IsVisible() && !ItemOnCursor()
+					&& globalIndex.GetLocation() == eItemContainerPossessions)
+				{
+					OpenContainer(pContainer, true);
+
+					CInvSlot* pInvSlot = GetInvSlot(globalIndex);
+
+					if (!pInvSlot || !pInvSlot->pInvSlotWnd || !SendWndClick2(pInvSlot->pInvSlotWnd, szNotification))
+					{
+						WriteChatf("Could not select item in %s %s for tribute donation.", szArg2, szArg3);
+					}
+
+					return;
+				}
+
 				// Either drop the item or pick it up, depending on whether we have an item on the cursor or not.
 				if (ItemOnCursor())
 				{
@@ -1608,6 +1627,29 @@ void ItemNotify(PSPAWNINFO pChar, char* szLine)
 			{
 				if (!_strnicmp(szNotification, "leftmouseup", 11))
 				{
+					// If the tribute master window is open, a left click should select the item as
+					// a donation instead of picking it up. That requires a real click on the slot's
+					// window, so open the container and send the click to it. The container is left
+					// open so that the selection remains valid until the donation is made.
+					if (pTributeMasterWnd && pTributeMasterWnd->IsVisible() && !ItemOnCursor()
+						&& pItem->GetItemLocation().GetLocation() == eItemContainerPossessions)
+					{
+						if (IsItemInsideContainer(pItem))
+						{
+							if (ItemClient* pContainer = FindItemByGlobalIndex(pItem->GetItemLocation().GetParent()))
+								OpenContainer(pContainer, true);
+						}
+
+						CInvSlot* pInvSlot = GetInvSlot(pItem->GetItemLocation());
+
+						if (!pInvSlot || !pInvSlot->pInvSlotWnd || !SendWndClick2(pInvSlot->pInvSlotWnd, szNotification))
+						{
+							WriteChatf("Could not select '%s' for tribute donation.", pItem->GetName());
+						}
+
+						return;
+					}
+
 					if (ItemOnCursor())
 					{
 						DropItem(pItem->GetItemLocation());


### PR DESCRIPTION
Fixes #874

### Bug

With the tribute donation window open and bags **closed**, `/itemnotify "some item" leftmouseup` picks the item up onto the cursor. With bags **open**, the same command correctly selects it as a tribute donation.

Cause: when the item's `CInvSlot` window doesn't exist (bag closed), `ItemNotify()` falls back to `PickupItem()`, which bypasses the client's slot-click handling — it special-cases the merchant window but has no tribute case. With bags open the command instead reaches `SendWndClick2` on the real slot window, and the client itself performs the donation selection.

### Fix

In both `PickupItem` fallback paths (named item, and `/itemnotify in <bag> <slot>`): when `pTributeMasterWnd` is visible, the cursor is empty, and the item is in possessions — open the item's container and send the click to the actual slot window, the same open-container + `SendWndClick2` technique the right-click spell-memming fallback in this function already uses. The container is left open so the selection remains valid until the user clicks Donate. If the slot still can't be resolved, the command reports an error instead of silently doing the wrong thing.

Behavior with an item already on the cursor is unchanged (drop). Note per eqlib's window table the client uses the same `TributeMasterWnd` screen for personal and guild tribute, so one check covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
