### PR TITLE
Warn when MQIniPath points at a missing ini

### DIFF
--- a/include/mq/base/Config.h
+++ b/include/mq/base/Config.h
@@ -363,8 +363,9 @@ inline std::string GetCreateMacroQuestIni(const std::filesystem::path& pathMQRoo
 			// If a custom MQIniPath was set but doesn't exist, warn the user since settings will not be loaded from it
 			if (pathMQini != pathFoundIni && !std::filesystem::exists(pathMQini, ec))
 			{
-				const std::string strTemp = "MQIniPath set in " + pathFoundIni.string() + " could not be found: " + pathMQini.string();
-				MessageBox(nullptr, strTemp.c_str(), "MacroQuest", MB_OK);
+				char szMessage[MAX_PATH * 2];
+				sprintf_s(szMessage, "MQIniPath set in %s could not be found: %s", pathFoundIni.string().c_str(), pathMQini.string().c_str());
+				MessageBox(nullptr, szMessage, "MacroQuest", MB_OK);
 			}
 		}
 

--- a/include/mq/base/Config.h
+++ b/include/mq/base/Config.h
@@ -343,6 +343,8 @@ inline std::string GetCreateMacroQuestIni(const std::filesystem::path& pathMQRoo
 
 		if (std::filesystem::exists(pathMQini, ec))
 		{
+			const std::filesystem::path pathFoundIni = pathMQini;
+
 			// Check to see if there is a different MacroQuest.ini we should be looking at
 			pathMQini = std::filesystem::path(GetPrivateProfileString("MacroQuest", "MQIniPath", pathMQini.string(), pathMQini.string()));
 
@@ -356,6 +358,13 @@ inline std::string GetCreateMacroQuestIni(const std::filesystem::path& pathMQRoo
 			if (is_directory(pathMQini, ec))
 			{
 				pathMQini = pathMQini / "MacroQuest.ini";
+			}
+
+			// If a custom MQIniPath was set but doesn't exist, warn the user since settings will not be loaded from it
+			if (pathMQini != pathFoundIni && !std::filesystem::exists(pathMQini, ec))
+			{
+				const std::string strTemp = "MQIniPath set in " + pathFoundIni.string() + " could not be found: " + pathMQini.string();
+				MessageBox(nullptr, strTemp.c_str(), "MacroQuest", MB_OK);
 			}
 		}
 


### PR DESCRIPTION
Fixes #922

### Problem

The directory keys (`ConfigPath`, `MacroPath`, …) already warn via MessageBox when their locations can't be found or created. But an `MQIniPath` redirect pointing at a **nonexistent** ini (the reporter's case: settings moved from an old computer) is silently accepted in `GetCreateMacroQuestIni` — every subsequent `GetPrivateProfileString` against it just returns defaults, with nothing in the console or a dialog to say why.

### Change

`GetCreateMacroQuestIni` is the single shared init point (used by both the loader's `InitializePaths` and the injected dll's `InitConfig`), so the check lives there: if a custom `MQIniPath` was set and the resolved ini doesn't exist, show the same style of MessageBox the directory-key failures already use:

> MQIniPath set in C:\MQ2\MacroQuest.ini could not be found: E:\OldPC\MQ\MacroQuest.ini

Warn-only by design — it deliberately does **not** fall back to the local ini, since pointing `MQIniPath` at a not-yet-created file and letting `WriteAllConfig` create it is a legitimate workflow, and a silent fallback would be its own surprise. If you'd prefer a fallback (or a DebugSpew instead of a dialog in the injected context), happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
