### PR TITLE
/lua parse: preserve quotes in the parsed expression

### DIFF
--- a/src/plugins/lua/MQ2Lua.cpp
+++ b/src/plugins/lua/MQ2Lua.cpp
@@ -1201,14 +1201,17 @@ void LuaCommand(SPAWNINFO* pChar, char* Buffer)
 		});
 
 	args::Command parse(commands, "parse", "parse a lua string with an available mq namespace",
-		[](args::Subparser& parser)
+		[Buffer](args::Subparser& parser)
 		{
 			args::Group arguments(parser, "", args::Group::Validators::DontCare);
 			args::PositionalList<std::string> script(arguments, "script", "the text of the lua script to run");
 			auto h = HelpFlag(parser);
 			parser.Parse();
 
-			if (script) LuaParseCommand(join(script.Get(), " "));
+			// Pass the original text following the parse subcommand so that quoting is
+			// preserved. Tokenizing and rejoining the arguments strips quotes from lua
+			// string literals (e.g. /lua parse 'two' == 'one' would become two == one).
+			if (script) LuaParseCommand(GetNextArg(Buffer));
 		});
 
 	args::Command stop(commands, "stop", "stop one or all running lua scripts",


### PR DESCRIPTION
Fixes #819

### Bug

```
/lua parse 'two' == 'one'     -> true
/lua parse ('two' == 'one')   -> false (correct)
```

The `parse` subcommand rebuilds the script by rejoining the tokenized arguments (`join(script.Get(), " ")`), and `tokenize_args`/`strip_quotes` remove single/double quotes from any token that begins **and** ends with the quote char. So the first form evaluates the chunk `two == one` — two undefined globals, `nil == nil`, `true`. The parenthesized form only works by accident: `('two'` doesn't begin with a quote, so its quotes survive. (The `=` sign in the issue title is a red herring.)

### Fix

Capture `Buffer` and pass the original text after the subcommand token — `LuaParseCommand(GetNextArg(Buffer))` — so quoting reaches Lua intact. `GetNextArg` is the core quote-aware argument skipper; the lambda runs synchronously inside `ParseArgs` while `Buffer` is alive, and `/lua parse -h` still works because `HelpFlag` throws before the call.

One intentional semantics change worth noting: `/lua parse "1+1"` previously had its outer quotes stripped and printed `2`; it now evaluates `return "1+1"` and prints the string `1+1` — i.e., quoted input is now a Lua string literal, which is the correct behavior for an evaluator and exactly what the issue asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
