### PR TITLE
Make Lua actor message handling robust to yields and errors

### DIFF
--- a/src/plugins/lua/LuaActor.cpp
+++ b/src/plugins/lua/LuaActor.cpp
@@ -457,18 +457,35 @@ void LuaDropbox::Receive(const std::shared_ptr<Message>& message)
 {
 	try
 	{
-		ScopedYieldDisabler disableYield(LuaThread::get_from(m_thread.state()));
+		std::shared_ptr<LuaThread> luaThread = LuaThread::get_from(m_thread.state());
+
+		// remove any existing hooks, they will be re-installed when running in onpulse.
+		// this prevents the forced-yield hook from suspending the message callback mid-
+		// execution, which would leave the coroutine suspended and corrupt it when the
+		// next message resumes it with a freshly pushed function and arguments.
+		if (luaThread)
+			lua_sethook(luaThread->GetLuaThread().lua_state(), nullptr, 0, 0);
+
+		ScopedYieldDisabler disableYield(luaThread);
 
 		sol::function_result result = m_coroutine(LuaMessage(this, message));
 		if (!result.valid())
 		{
 			LuaError("Lua Actor Failure:\n%s", sol::stack::get<std::string>(result.lua_state(), result.stack_index()).c_str());
 			result.abandon();
+
+			// an error in the callback leaves the coroutine's thread in a state that can never
+			// be resumed again, so recreate it to allow subsequent messages to be processed
+			m_thread = sol::thread::create(m_parentThread.state());
+			m_coroutine = sol::coroutine(m_thread.state(), m_callback);
 		}
 	}
 	catch (std::runtime_error& e)
 	{
 		LuaError("Lua Actor Failure:\n%s", e.what());
+
+		m_thread = sol::thread::create(m_parentThread.state());
+		m_coroutine = sol::coroutine(m_thread.state(), m_callback);
 	}
 }
 


### PR DESCRIPTION
Fixes #842
Fixes #854

Two defects in the same few lines of `LuaDropbox::Receive` — which resumes one persistent coroutine for every incoming actor message — with compounding symptoms. One PR because the edits interlock in the same function.

### #854 — VM corruption crash (dangling `lua_State` in `ParseHeader`)

The forced-yield debug hook (`LuaThread::YieldAt` → `lua_forceYield`) is left armed when the post office delivers a message. Under LuaJIT, debug hooks live in the `global_State` — they fire in **every** coroutine of the VM, not just the script coroutine they were set on — and `lua_forceYield` never consults `GetAllowYield()`, so the `ScopedYieldDisabler` can't stop it. When the leftover instruction budget expires mid-handler, the handler coroutine yields silently (sol treats `call_status::yielded` as `valid()`), and the **next** message pushes a fresh function + arguments onto the *suspended* coroutine and resumes into the middle of the interrupted handler — corrupting the stack, with the crash surfacing later exactly as in the issue's dump (`Receive` → `ParseHeader` → `state_view(nullptr)` → AV). The probabilistic 1–5 minute window at ~1 msg/sec matches the hook-expiry timing.

The two sibling paths that resume side coroutines already unset the hook first, with a comment saying why (`LuaDropbox::Process`, `LuaImGuiProcessor::Pulse`). `Receive` was the one resume path missing the guard — a regression from 7820f506 ("Localized the hook unset to actors"), which removed the hook-clearing that `SetAllowYield(false)` used to do and re-added it only to `Process`. This restores the lost protection in the established pattern; the hook is re-armed by `YieldAt(m_turboNum)` at the next script resume.

### #842 — one handler error permanently breaks the actor

When the handler raises a Lua error, the coroutine's thread enters an error status that LuaJIT permanently refuses to resume — every subsequent message fails with `cannot resume non-suspended coroutine`. After a failed invocation, recreate `m_thread`/`m_coroutine` exactly as the constructor builds them, so the next message gets a fresh resumable thread. `ScopedYieldDisabler` holds its own `shared_ptr` and `result.abandon()` runs before the reassignment, so nothing touches the discarded thread. (The issue's side note about empty tables serializing to nil is a separate `SerializeProto` design question, intentionally not touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
