### PR TITLE
Clear the switch target when it leaves the switch manager

### DIFF
--- a/src/main/MQ2Pulse.cpp
+++ b/src/main/MQ2Pulse.cpp
@@ -701,6 +701,31 @@ static HeartbeatState Heartbeat()
 
 	UpdateMQ2SpawnSort();
 
+	// Switches are deallocated when the zone unloads, which can happen before we
+	// detect that we are zoning. If the switch target is no longer in the switch
+	// manager, clear it so that we never hold a dangling pointer. See #857.
+	if (pSwitchTarget)
+	{
+		bool switchExists = false;
+
+		if (pSwitchMgr)
+		{
+			for (int i = 0; i < pSwitchMgr->NumEntries; ++i)
+			{
+				if (pSwitchMgr->Switches[i] == pSwitchTarget)
+				{
+					switchExists = true;
+					break;
+				}
+			}
+		}
+
+		if (!switchExists)
+		{
+			SetSwitchTarget(nullptr);
+		}
+	}
+
 	DebugTry(DrawHUD());
 	DebugTry(PulseMQ2AutoInventory());
 


### PR DESCRIPTION
Fixes #857

### Bug

Switches are deallocated when the old zone unloads, and (as the issue notes) that can happen **before** MQ detects it is zoning. The only automatic clear of `pSwitchTarget` is the `SetSwitchTarget(nullptr)` in the `WereWeZoning` reset block — i.e. after zoning *completes* — so for the intervening pulse(s), `${Switch...}`, `/face door`, plugins reading `pSwitchTarget`, and the switch inspector can dereference a freed `EQSwitch`.

Ground items already have proactive invalidation via the `EQGroundItemListManager` Clear/Delete detours; switches have no equivalent teardown hook, and adding one would require a new eqlib offset.

### Fix

Offset-free: validate by **pointer identity** each heartbeat. If `pSwitchTarget` is no longer present in `pSwitchMgr->Switches[]`, clear it via `SetSwitchTarget(nullptr)` (which also clears the deprecated `pDoorTarget`). The stale pointer is never dereferenced — only compared. Every legitimate switch target originates from the manager (`GetSwitchByID`/`FindSwitchByName`/the switch type's `Target` method all iterate it), so membership is a sound validity test; the scan is at most `NumEntries` pointer compares per heartbeat.

Placed before `DrawHUD()` so plugin `OnDrawHUD` callbacks are covered along with `Pulse`/`PulsePlugins`/macros/ImGui. Residual window that polling can't close: the render path (`ImGuiManager_DrawFrame`, `DrawNetStatus`) can still observe the pointer between the client's teardown and the next heartbeat — fully closing that would need the teardown-hook approach with a new eqlib offset; this covers the pulse-level race the issue reports without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
