### PR TITLE
Fix Find Item Window destroy feature never deleting items

### DIFF
--- a/src/main/MQ2AutoInventory.cpp
+++ b/src/main/MQ2AutoInventory.cpp
@@ -1079,7 +1079,10 @@ static void FindItemPulse()
 
 	if (gbStartDeleting)
 	{
-		if (pCursorAttachment && pCursorAttachment->Type == eCursorAttachment_None)
+		// Wait until the cursor is empty before picking up the next item. We can't rely on
+		// pCursorAttachment->Type here because the game no longer resets it to eCursorAttachment_None.
+		PcProfile* pProfile = GetPcProfile();
+		if (pProfile && !pProfile->GetInventorySlot(InvSlot_Cursor))
 		{
 			// user wants us to delete stuff. Delete one item per frame.
 			if (!gDeleteList.empty())


### PR DESCRIPTION
Fixes #738

### Bug

The Find Item Window "Destroy" checkbox queues checked items into `gDeleteList` but never actually destroys any of them. `FindItemPulse()` gates the per-frame delete loop on:

```cpp
if (pCursorAttachment && pCursorAttachment->Type == eCursorAttachment_None)
```

The game no longer resets `pCursorAttachment->Type` to `eCursorAttachment_None` when the cursor is empty, so this is never true — `gDeleteList` is never drained and `gbStartDeleting` stays set forever. (Collaborator Sicprofundus confirmed in the issue thread that removing this exact check makes the feature work.)

### Fix

The check's only purpose is to wait until the cursor is empty before picking up the next item. Use the same "cursor empty" test this feature's own button-click handler already uses a few hundred lines up:

```cpp
PcProfile* pProfile = GetPcProfile();
if (pProfile && !pProfile->GetInventorySlot(InvSlot_Cursor))
```

This restores the feature while keeping the one-item-per-frame throttle (unlike simply deleting the check). `FindItemPulse()` already early-returns on `!pLocalPC`; the `pProfile` null guard is there for safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
