### PR TITLE
Skip anonymizer replacement work when the text doesn't match

### DIFF
--- a/src/main/MQ2Anonymize.cpp
+++ b/src/main/MQ2Anonymize.cpp
@@ -266,6 +266,13 @@ public:
 
 	std::string replace_text(std::string_view text) const
 	{
+		// Most rendered text won't match, and this runs inside per-frame draw detours for
+		// every replacer. Bail out before computing the replacement (which does spawn
+		// lookups, macro parsing and formatting) or rebuilding the string when there is
+		// no match at all.
+		if (!std::regex_search(std::cbegin(text), std::cend(text), search_string))
+			return std::string(text);
+
 		std::string result;
 		std::regex_replace(std::back_inserter(result), std::cbegin(text), std::cend(text), search_string, anonymize());
 		return result;


### PR DESCRIPTION
Fixes #752

### Problem

`Anonymize()` runs inside per-frame render detours (`CTextureFont::DrawWrappedText` ×3 and `GetGaugeValueFromEQ`), so `anon_replacer::replace_text` executes for **every text element drawn, every frame, once per configured replacer**. A 6-boxer typically anonymizes 6+ names.

```cpp
std::regex_replace(std::back_inserter(result), begin, end, search_string, anonymize());
```

`anonymize()` is passed as the replacement argument, so it's evaluated **eagerly — before regex_replace knows whether the pattern matches**. It's expensive per strategy: `Class` does a `GetSpawnByName()` spawn-manager lookup, `Custom` runs the full macro parser via `ModifyMacroString`, `Me` does `GetPcProfile()` + `fmt::format` — all allocate. And `regex_replace` rebuilds the whole string through an unreserved `back_inserter` even when nothing matches. So every drawn string pays N spawn-lookups/macro-parses/format-allocations plus N full rebuild passes, per frame.

(The regexes themselves are prebuilt/memoized, not recompiled per line — so that's not the hotspot.)

### Fix

Short-circuit with a `std::regex_search` and return the text unchanged on a non-match (the overwhelmingly common case), so the expensive replacement is computed only when the pattern actually matches:

```cpp
if (!std::regex_search(begin, end, search_string))
    return std::string(text);
```

Output is behavior-identical (`regex_replace` on a non-match copies the input verbatim, which the early return reproduces; `anonymize()` is `const` and side-effect-free). `replace_text` is the single funnel for all replacer call sites and has no callers outside this file. Matching strings pay one extra scan (search then replace), negligible since matches are rare and strings are short.

This removes the dominant per-frame cost. Two smaller hotspots remain for a future pass and are out of scope here: one `regex_search` per replacer per drawn string still runs, and the guild path still walks the full guild roster per call when guild anonymization is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
